### PR TITLE
Implemented a quick sort and de-sort for 2-phase ADF font-back scans.

### DIFF
--- a/NAPS2.Core/Scan/Images/ScannedImageList.cs
+++ b/NAPS2.Core/Scan/Images/ScannedImageList.cs
@@ -6,6 +6,7 @@
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
     Copyright (C) 2012-2015  Ben Olden-Cooligan
+    Copyright (C) 2015       Luca De Petrillo
 
     This program is free software; you can redistribute it and/or
     modify it under the terms of the GNU General Public License
@@ -180,6 +181,48 @@ namespace NAPS2.Scan.Images
                 img.SetThumbnail(img.RenderThumbnail(UserConfigManager.Config.ThumbnailSize));
             }
             return selection.ToList();
+        }
+
+        internal IEnumerable<int> FrontBackAdfSort()
+        {
+            // Partition the image list in two
+            int count = Images.Count;
+            int split = (count + 1) / 2;
+            var p1 = Images.Take(split).ToList();
+            var p2 = Images.Skip(split).ToList();
+
+            // Rebuild the image list, taking alternating images from start of the 1st partitions 
+            // and from end of the 2nd partition
+            Images.Clear();
+            for (int i = 0; i < count; ++i)
+            {
+                Images.Add(i % 2 == 0 ? p1[i / 2] : p2[p2.Count - 1 - (i / 2)]);
+            }
+
+            // Clear the selection (may be changed in the future to maintain it, but not necessary)
+            return Enumerable.Empty<int>();
+        }
+
+        internal IEnumerable<int> FrontBackAdfDesort()
+        {
+            // Duplicate the list
+            int count = Images.Count;
+            int split = (count + 1) / 2;
+            var images = Images.ToList();
+
+            // Rebuild the image list, even-indexed images first and odd-indexed image after in reverse order
+            Images.Clear();
+            for (int i = 0; i < split; ++i)
+            {
+                Images.Add(images[i * 2]);
+            }
+            for (int i = (count - split) - 1; i >= 0; --i)
+            {
+                Images.Add(images[i * 2 + 1]);
+            }
+
+            // Clear the selection (may be changed in the future to maintain it, but not necessary)
+            return Enumerable.Empty<int>();
         }
     }
 }

--- a/NAPS2.Core/WinForms/FDesktop.Designer.cs
+++ b/NAPS2.Core/WinForms/FDesktop.Designer.cs
@@ -58,6 +58,8 @@ namespace NAPS2.WinForms
             this.tsdSaveImages = new System.Windows.Forms.ToolStripSplitButton();
             this.tsSaveImagesAll = new System.Windows.Forms.ToolStripMenuItem();
             this.tsSaveImagesSelected = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsImageSettings = new System.Windows.Forms.ToolStripMenuItem();
             this.tsdEmailPDF = new System.Windows.Forms.ToolStripSplitButton();
             this.tsEmailPDFAll = new System.Windows.Forms.ToolStripMenuItem();
             this.tsEmailPDFSelected = new System.Windows.Forms.ToolStripMenuItem();
@@ -87,14 +89,16 @@ namespace NAPS2.WinForms
             this.tsReverse = new System.Windows.Forms.ToolStripMenuItem();
             this.tsReverseAll = new System.Windows.Forms.ToolStripMenuItem();
             this.tsReverseSelected = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsFrontBackAdf = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.tsDelete = new System.Windows.Forms.ToolStripButton();
             this.tsClear = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
             this.tsAbout = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.tsImageSettings = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsFrontBackAdfSort = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsFrontBackAdfDeSort = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripContainer1.ContentPanel.SuspendLayout();
             this.toolStripContainer1.TopToolStripPanel.SuspendLayout();
             this.toolStripContainer1.SuspendLayout();
@@ -320,6 +324,17 @@ namespace NAPS2.WinForms
             resources.ApplyResources(this.tsSaveImagesSelected, "tsSaveImagesSelected");
             this.tsSaveImagesSelected.Click += new System.EventHandler(this.tsSaveImagesSelected_Click);
             // 
+            // toolStripSeparator11
+            // 
+            this.toolStripSeparator11.Name = "toolStripSeparator11";
+            resources.ApplyResources(this.toolStripSeparator11, "toolStripSeparator11");
+            // 
+            // tsImageSettings
+            // 
+            this.tsImageSettings.Name = "tsImageSettings";
+            resources.ApplyResources(this.tsImageSettings, "tsImageSettings");
+            this.tsImageSettings.Click += new System.EventHandler(this.tsImageSettings_Click);
+            // 
             // tsdEmailPDF
             // 
             this.tsdEmailPDF.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -495,7 +510,9 @@ namespace NAPS2.WinForms
             this.tsInterleave,
             this.tsDeinterleave,
             this.toolStripSeparator1,
-            this.tsReverse});
+            this.tsReverse,
+            this.toolStripMenuItem1,
+            this.tsFrontBackAdf});
             this.tsdReorder.Image = global::NAPS2.Icons.arrow_refresh;
             resources.ApplyResources(this.tsdReorder, "tsdReorder");
             this.tsdReorder.Name = "tsdReorder";
@@ -539,6 +556,19 @@ namespace NAPS2.WinForms
             resources.ApplyResources(this.tsReverseSelected, "tsReverseSelected");
             this.tsReverseSelected.Click += new System.EventHandler(this.tsReverseSelected_Click);
             // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
+            // 
+            // tsFrontBackAdf
+            // 
+            this.tsFrontBackAdf.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsFrontBackAdfSort,
+            this.tsFrontBackAdfDeSort});
+            this.tsFrontBackAdf.Name = "tsFrontBackAdf";
+            resources.ApplyResources(this.tsFrontBackAdf, "tsFrontBackAdf");
+            // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
@@ -580,16 +610,17 @@ namespace NAPS2.WinForms
             this.tsAbout.Padding = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.tsAbout.Click += new System.EventHandler(this.tsAbout_Click);
             // 
-            // toolStripSeparator11
+            // tsFrontBackAdfSort
             // 
-            this.toolStripSeparator11.Name = "toolStripSeparator11";
-            resources.ApplyResources(this.toolStripSeparator11, "toolStripSeparator11");
+            this.tsFrontBackAdfSort.Name = "tsFrontBackAdfSort";
+            resources.ApplyResources(this.tsFrontBackAdfSort, "tsFrontBackAdfSort");
+            this.tsFrontBackAdfSort.Click += new System.EventHandler(this.tsFrontBackAdfSort_Click);
             // 
-            // tsImageSettings
+            // tsFrontBackAdfDeSort
             // 
-            this.tsImageSettings.Name = "tsImageSettings";
-            resources.ApplyResources(this.tsImageSettings, "tsImageSettings");
-            this.tsImageSettings.Click += new System.EventHandler(this.tsImageSettings_Click);
+            this.tsFrontBackAdfDeSort.Name = "tsFrontBackAdfDeSort";
+            resources.ApplyResources(this.tsFrontBackAdfDeSort, "tsFrontBackAdfDeSort");
+            this.tsFrontBackAdfDeSort.Click += new System.EventHandler(this.tsFrontBackAdfDeSort_Click);
             // 
             // FDesktop
             // 
@@ -676,6 +707,10 @@ namespace NAPS2.WinForms
         private System.Windows.Forms.Button btnZoomOut;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
         private System.Windows.Forms.ToolStripMenuItem tsImageSettings;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem tsFrontBackAdf;
+        private System.Windows.Forms.ToolStripMenuItem tsFrontBackAdfSort;
+        private System.Windows.Forms.ToolStripMenuItem tsFrontBackAdfDeSort;
     }
 }
 

--- a/NAPS2.Core/WinForms/FDesktop.cs
+++ b/NAPS2.Core/WinForms/FDesktop.cs
@@ -6,6 +6,7 @@
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
     Copyright (C) 2012-2015  Ben Olden-Cooligan
+    Copyright (C) 2015       Luca De Petrillo
 
     This program is free software; you can redistribute it and/or
     modify it under the terms of the GNU General Public License
@@ -863,6 +864,26 @@ namespace NAPS2.WinForms
                 return;
             }
             UpdateThumbnails(imageList.Deinterleave(SelectedIndices));
+            changeTracker.HasUnsavedChanges = true;
+        }
+
+        private void tsFrontBackAdfSort_Click(object sender, EventArgs e)
+        {
+            if (imageList.Images.Count < 3)
+            {
+                return;
+            }
+            UpdateThumbnails(imageList.FrontBackAdfSort());
+            changeTracker.HasUnsavedChanges = true;
+        }
+
+        private void tsFrontBackAdfDeSort_Click(object sender, EventArgs e)
+        {
+            if (imageList.Images.Count < 3)
+            {
+                return;
+            }
+            UpdateThumbnails(imageList.FrontBackAdfDesort());
             changeTracker.HasUnsavedChanges = true;
         }
 

--- a/NAPS2.Core/WinForms/FDesktop.resx
+++ b/NAPS2.Core/WinForms/FDesktop.resx
@@ -211,7 +211,7 @@
     <value>thumbnailList1</value>
   </data>
   <data name="&gt;&gt;thumbnailList1.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.ThumbnailList, NAPS2.Core, Version=4.0.2.31892, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.ThumbnailList, NAPS2.Core, Version=4.1.1.21423, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;thumbnailList1.Parent" xml:space="preserve">
     <value>toolStripContainer1.ContentPanel</value>
@@ -376,27 +376,6 @@
   <data name="tsdSavePDF.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
-  <data name="tsSaveImagesAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 22</value>
-  </data>
-  <data name="tsSaveImagesAll.Text" xml:space="preserve">
-    <value>All ({0})</value>
-  </data>
-  <data name="tsSaveImagesSelected.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 22</value>
-  </data>
-  <data name="tsSaveImagesSelected.Text" xml:space="preserve">
-    <value>Selected ({0})</value>
-  </data>
-  <data name="toolStripSeparator11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 6</value>
-  </data>
-  <data name="tsImageSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 22</value>
-  </data>
-  <data name="tsImageSettings.Text" xml:space="preserve">
-    <value>Image Settings</value>
-  </data>
   <data name="tsdSaveImages.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
   </data>
@@ -462,6 +441,54 @@
   </data>
   <data name="tsMove.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 51</value>
+  </data>
+  <data name="tsInterleave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 22</value>
+  </data>
+  <data name="tsInterleave.Text" xml:space="preserve">
+    <value>Interleave</value>
+  </data>
+  <data name="tsDeinterleave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 22</value>
+  </data>
+  <data name="tsDeinterleave.Text" xml:space="preserve">
+    <value>Deinterleave</value>
+  </data>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 6</value>
+  </data>
+  <data name="tsReverse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 22</value>
+  </data>
+  <data name="tsReverse.Text" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 6</value>
+  </data>
+  <data name="tsFrontBackAdfSort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 22</value>
+  </data>
+  <data name="tsFrontBackAdfSort.Text" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="tsFrontBackAdfSort.ToolTipText" xml:space="preserve">
+    <value>1, 3, 5, 6, 4, 2 -&gt; 1, 2, 3, 4, 5, 6</value>
+  </data>
+  <data name="tsFrontBackAdfDeSort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 22</value>
+  </data>
+  <data name="tsFrontBackAdfDeSort.Text" xml:space="preserve">
+    <value>De-sort</value>
+  </data>
+  <data name="tsFrontBackAdfDeSort.ToolTipText" xml:space="preserve">
+    <value>1, 2, 3, 4, 5, 6 -&gt; 1, 3, 5, 6, 4, 2</value>
+  </data>
+  <data name="tsFrontBackAdf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 22</value>
+  </data>
+  <data name="tsFrontBackAdf.Text" xml:space="preserve">
+    <value>Front-Back ADF</value>
   </data>
   <data name="tsdReorder.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -573,7 +600,7 @@
     <value>3, 0</value>
   </data>
   <data name="tStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1201, 54</value>
+    <value>1184, 54</value>
   </data>
   <data name="tStrip.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -657,25 +684,46 @@
     <value>New Profile</value>
   </data>
   <data name="tsSavePDFAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 22</value>
+    <value>143, 22</value>
   </data>
   <data name="tsSavePDFAll.Text" xml:space="preserve">
     <value>All ({0})</value>
   </data>
   <data name="tsSavePDFSelected.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 22</value>
+    <value>143, 22</value>
   </data>
   <data name="tsSavePDFSelected.Text" xml:space="preserve">
     <value>Selected ({0})</value>
   </data>
   <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 6</value>
+    <value>140, 6</value>
   </data>
   <data name="tsPDFSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 22</value>
+    <value>143, 22</value>
   </data>
   <data name="tsPDFSettings.Text" xml:space="preserve">
     <value>PDF Settings</value>
+  </data>
+  <data name="tsSaveImagesAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 22</value>
+  </data>
+  <data name="tsSaveImagesAll.Text" xml:space="preserve">
+    <value>All ({0})</value>
+  </data>
+  <data name="tsSaveImagesSelected.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 22</value>
+  </data>
+  <data name="tsSaveImagesSelected.Text" xml:space="preserve">
+    <value>Selected ({0})</value>
+  </data>
+  <data name="toolStripSeparator11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 6</value>
+  </data>
+  <data name="tsImageSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 22</value>
+  </data>
+  <data name="tsImageSettings.Text" xml:space="preserve">
+    <value>Image Settings</value>
   </data>
   <data name="tsEmailPDFAll.Size" type="System.Drawing.Size, System.Drawing">
     <value>148, 22</value>
@@ -782,35 +830,14 @@
   <data name="customRotationToolStripMenuItem.Text" xml:space="preserve">
     <value>Custom Rotation</value>
   </data>
-  <data name="tsInterleave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 22</value>
-  </data>
-  <data name="tsInterleave.Text" xml:space="preserve">
-    <value>Interleave</value>
-  </data>
-  <data name="tsDeinterleave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 22</value>
-  </data>
-  <data name="tsDeinterleave.Text" xml:space="preserve">
-    <value>Deinterleave</value>
-  </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 6</value>
-  </data>
-  <data name="tsReverse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 22</value>
-  </data>
-  <data name="tsReverse.Text" xml:space="preserve">
-    <value>Reverse</value>
-  </data>
   <data name="tsReverseAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 22</value>
+    <value>152, 22</value>
   </data>
   <data name="tsReverseAll.Text" xml:space="preserve">
     <value>All ({0})</value>
   </data>
   <data name="tsReverseSelected.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 22</value>
+    <value>152, 22</value>
   </data>
   <data name="tsReverseSelected.Text" xml:space="preserve">
     <value>Selected ({0})</value>
@@ -959,6 +986,18 @@
   <data name="&gt;&gt;tsSaveImagesSelected.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator11.Name" xml:space="preserve">
+    <value>toolStripSeparator11</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsImageSettings.Name" xml:space="preserve">
+    <value>tsImageSettings</value>
+  </data>
+  <data name="&gt;&gt;tsImageSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;tsdEmailPDF.Name" xml:space="preserve">
     <value>tsdEmailPDF</value>
   </data>
@@ -1089,7 +1128,7 @@
     <value>tsMove</value>
   </data>
   <data name="&gt;&gt;tsMove.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.ToolStripDoubleButton, NAPS2.Core, Version=4.0.2.31892, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.ToolStripDoubleButton, NAPS2.Core, Version=4.1.1.21423, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tsdReorder.Name" xml:space="preserve">
     <value>tsdReorder</value>
@@ -1133,6 +1172,18 @@
   <data name="&gt;&gt;tsReverseSelected.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
+    <value>toolStripMenuItem1</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsFrontBackAdf.Name" xml:space="preserve">
+    <value>tsFrontBackAdf</value>
+  </data>
+  <data name="&gt;&gt;tsFrontBackAdf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
     <value>toolStripSeparator2</value>
   </data>
@@ -1169,22 +1220,22 @@
   <data name="&gt;&gt;tsAbout.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator11.Name" xml:space="preserve">
-    <value>toolStripSeparator11</value>
+  <data name="&gt;&gt;tsFrontBackAdfSort.Name" xml:space="preserve">
+    <value>tsFrontBackAdfSort</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tsFrontBackAdfSort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tsImageSettings.Name" xml:space="preserve">
-    <value>tsImageSettings</value>
+  <data name="&gt;&gt;tsFrontBackAdfDeSort.Name" xml:space="preserve">
+    <value>tsFrontBackAdfDeSort</value>
   </data>
-  <data name="&gt;&gt;tsImageSettings.Type" xml:space="preserve">
+  <data name="&gt;&gt;tsFrontBackAdfDeSort.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>FDesktop</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=4.0.2.31892, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=4.1.1.21423, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
Hi,
I tried to implement a quick sort and de-sort reordering function for front+back scans using the ADF in 2 phases (1st phase front sides starting from the first page, 2nd phase back sides starting from last page).

The reordering function works for even and odd number of pages (for example, when the last page is removed in the 2nd scan phase because it is blank), they require at least 3 images and are applied on all loaded images (no partial selection or reordering).

Let me know if there are things to fix.

Bye,
Luca