### PR TITLE
Added an option to enable PDF image compression with a customizable quality

### DIFF
--- a/NAPS2.Core/ImportExport/Pdf/PdfImageSettings.cs
+++ b/NAPS2.Core/ImportExport/Pdf/PdfImageSettings.cs
@@ -1,0 +1,37 @@
+/*
+    NAPS2 (Not Another PDF Scanner 2)
+    http://sourceforge.net/projects/naps2/
+    
+    Copyright (C) 2015       Luca De Petrillo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+*/
+
+using NAPS2.Lang.Resources;
+
+namespace NAPS2.ImportExport.Pdf
+{
+    public class PdfImageSettings
+    {
+        public const int DEFAULT_JPEG_QUALITY = 75;
+        public const bool DEFAULT_COMPRESS_IMAGES = false;
+
+        public PdfImageSettings()
+        {
+            JpegQuality = DEFAULT_JPEG_QUALITY;
+            CompressImages = DEFAULT_COMPRESS_IMAGES;
+        }
+
+        public int JpegQuality { get; set; }
+
+        public bool CompressImages { get; set; }
+    }
+}

--- a/NAPS2.Core/ImportExport/Pdf/PdfSettings.cs
+++ b/NAPS2.Core/ImportExport/Pdf/PdfSettings.cs
@@ -5,6 +5,7 @@
     Copyright (C) 2009       Pavel Sorejs
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
+    Copyright (C) 2015       Luca De Petrillo
     Copyright (C) 2012-2015  Ben Olden-Cooligan
 
     This program is free software; you can redistribute it and/or
@@ -27,11 +28,13 @@ namespace NAPS2.ImportExport.Pdf
     public class PdfSettings
     {
         private PdfMetadata metadata;
+        private PdfImageSettings imageSettings;
         private PdfEncryption encryption;
 
         public PdfSettings()
         {
             metadata = new PdfMetadata();
+            imageSettings = new PdfImageSettings();
             encryption = new PdfEncryption();
         }
 
@@ -47,6 +50,19 @@ namespace NAPS2.ImportExport.Pdf
                     throw new ArgumentNullException("value");
                 }
                 metadata = value;
+            }
+        }
+
+        public PdfImageSettings ImageSettings
+        {
+            get { return imageSettings; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+                imageSettings = value;
             }
         }
 

--- a/NAPS2.Core/NAPS2.Core.csproj
+++ b/NAPS2.Core/NAPS2.Core.csproj
@@ -81,6 +81,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Icons.resx</DependentUpon>
     </Compile>
+    <Compile Include="ImportExport\Pdf\PdfImageSettings.cs" />
     <Compile Include="ImportExport\Pdf\PdfSaver.cs" />
     <Compile Include="Util\ChangeTracker.cs" />
     <Compile Include="Util\CollectionExtensions.cs" />

--- a/NAPS2.Core/Scan/Images/FileBasedScannedImage.cs
+++ b/NAPS2.Core/Scan/Images/FileBasedScannedImage.cs
@@ -5,6 +5,7 @@
     Copyright (C) 2009       Pavel Sorejs
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
+    Copyright (C) 2015       Luca De Petrillo
     Copyright (C) 2012-2015  Ben Olden-Cooligan
 
     This program is free software; you can redistribute it and/or
@@ -69,9 +70,12 @@ namespace NAPS2.Scan.Images
         // Store a base image and transform pair (rather than doing the actual transform on the base image)
         // so that JPEG degradation is minimized when multiple rotations/flips are performed
         private readonly List<Transform> transformList = new List<Transform>();
+        private readonly bool highQuality;
 
         public FileBasedScannedImage(Bitmap img, ScanBitDepth bitDepth, bool highQuality)
         {
+            this.highQuality = highQuality;
+
             Bitmap baseImage;
             MemoryStream baseImageEncoded;
             ScannedImageHelper.GetSmallestBitmap(img, bitDepth, highQuality, out baseImage, out baseImageEncoded, out baseImageFileFormat);
@@ -213,6 +217,11 @@ namespace NAPS2.Scan.Images
             _recoveryIndexManager.Index.Images.Remove(indexImage);
             _recoveryIndexManager.Index.Images.Insert(index, indexImage);
             _recoveryIndexManager.Save();
+        }
+
+        public bool IsHighQuality()
+        {
+            return highQuality;
         }
     }
 }

--- a/NAPS2.Core/Scan/Images/IScannedImage.cs
+++ b/NAPS2.Core/Scan/Images/IScannedImage.cs
@@ -5,6 +5,7 @@
     Copyright (C) 2009       Pavel Sorejs
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
+    Copyright (C) 2015       Luca De Petrillo
     Copyright (C) 2012-2015  Ben Olden-Cooligan
 
     This program is free software; you can redistribute it and/or
@@ -77,5 +78,11 @@ namespace NAPS2.Scan.Images
         /// </summary>
         /// <param name="index">The index at which the image was inserted after being removed.</param>
         void MovedTo(int index);
+
+
+        /// <summary>
+        /// Indicates if the scanned image has been acquired using "High Quality" configuration, or if it has been imported using a lossless format.
+        /// </summary>
+        bool IsHighQuality();
     }
 }

--- a/NAPS2.Core/Scan/Images/ScannedImage.cs
+++ b/NAPS2.Core/Scan/Images/ScannedImage.cs
@@ -5,6 +5,7 @@
     Copyright (C) 2009       Pavel Sorejs
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
+    Copyright (C) 2015       Luca De Petrillo
     Copyright (C) 2012-2015  Ben Olden-Cooligan
 
     This program is free software; you can redistribute it and/or
@@ -34,6 +35,7 @@ namespace NAPS2.Scan.Images
         private Bitmap thumbnail;
         // The image's bit depth (or C24Bit if unknown)
         private readonly ScanBitDepth bitDepth;
+        private readonly bool highQuality;
         // Only one of the following (baseImage/baseImageEncoded) should have a value for any particular ScannedImage
         private readonly Bitmap baseImage;
         private readonly MemoryStream baseImageEncoded;
@@ -42,9 +44,12 @@ namespace NAPS2.Scan.Images
         // so that JPEG degradation is minimized when multiple rotations/flips are performed
         private readonly List<Transform> transformList = new List<Transform>();
 
+        
         public ScannedImage(Bitmap img, ScanBitDepth bitDepth, bool highQuality)
         {
             this.bitDepth = bitDepth;
+            this.highQuality = highQuality;
+
             ScannedImageHelper.GetSmallestBitmap(img, bitDepth, highQuality, out baseImage, out baseImageEncoded, out baseImageFileFormat);
         }
 
@@ -125,6 +130,11 @@ namespace NAPS2.Scan.Images
         public void MovedTo(int index)
         {
             // Do nothing, this is only important for FileBasedScannedImage
+        }
+
+        public bool IsHighQuality()
+        {
+            return highQuality;
         }
     }
 }

--- a/NAPS2.Core/WinForms/FPdfSettings.Designer.cs
+++ b/NAPS2.Core/WinForms/FPdfSettings.Designer.cs
@@ -67,8 +67,16 @@ namespace NAPS2.WinForms
             this.linkPlaceholders = new System.Windows.Forms.LinkLabel();
             this.txtDefaultFileName = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.groupImage = new System.Windows.Forms.GroupBox();
+            this.lbCompressImageQuality = new System.Windows.Forms.Label();
+            this.cbCompressImagePdf = new System.Windows.Forms.CheckBox();
+            this.lblImageCompressionInfo = new System.Windows.Forms.Label();
+            this.txtJpegQuality = new System.Windows.Forms.TextBox();
+            this.tbJpegQuality = new System.Windows.Forms.TrackBar();
             this.groupMetadata.SuspendLayout();
             this.groupProtection.SuspendLayout();
+            this.groupImage.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.tbJpegQuality)).BeginInit();
             this.SuspendLayout();
             // 
             // btnOK
@@ -281,10 +289,53 @@ namespace NAPS2.WinForms
             resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
             // 
+            // groupImage
+            // 
+            this.groupImage.Controls.Add(this.lbCompressImageQuality);
+            this.groupImage.Controls.Add(this.cbCompressImagePdf);
+            this.groupImage.Controls.Add(this.lblImageCompressionInfo);
+            this.groupImage.Controls.Add(this.txtJpegQuality);
+            this.groupImage.Controls.Add(this.tbJpegQuality);
+            resources.ApplyResources(this.groupImage, "groupImage");
+            this.groupImage.Name = "groupImage";
+            this.groupImage.TabStop = false;
+            // 
+            // lbCompressImageQuality
+            // 
+            resources.ApplyResources(this.lbCompressImageQuality, "lbCompressImageQuality");
+            this.lbCompressImageQuality.Name = "lbCompressImageQuality";
+            // 
+            // cbCompressImagePdf
+            // 
+            resources.ApplyResources(this.cbCompressImagePdf, "cbCompressImagePdf");
+            this.cbCompressImagePdf.Name = "cbCompressImagePdf";
+            this.cbCompressImagePdf.UseVisualStyleBackColor = true;
+            this.cbCompressImagePdf.CheckedChanged += new System.EventHandler(this.cbCompressImagePdf_CheckedChanged);
+            // 
+            // lblImageCompressionInfo
+            // 
+            resources.ApplyResources(this.lblImageCompressionInfo, "lblImageCompressionInfo");
+            this.lblImageCompressionInfo.Name = "lblImageCompressionInfo";
+            // 
+            // txtJpegQuality
+            // 
+            resources.ApplyResources(this.txtJpegQuality, "txtJpegQuality");
+            this.txtJpegQuality.Name = "txtJpegQuality";
+            this.txtJpegQuality.TextChanged += new System.EventHandler(this.txtJpegQuality_TextChanged);
+            // 
+            // tbJpegQuality
+            // 
+            resources.ApplyResources(this.tbJpegQuality, "tbJpegQuality");
+            this.tbJpegQuality.Maximum = 100;
+            this.tbJpegQuality.Name = "tbJpegQuality";
+            this.tbJpegQuality.TickFrequency = 25;
+            this.tbJpegQuality.Scroll += new System.EventHandler(this.tbJpegQuality_Scroll);
+            // 
             // FPdfSettings
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupImage);
             this.Controls.Add(this.linkPlaceholders);
             this.Controls.Add(this.txtDefaultFileName);
             this.Controls.Add(this.label1);
@@ -301,6 +352,9 @@ namespace NAPS2.WinForms
             this.groupMetadata.PerformLayout();
             this.groupProtection.ResumeLayout(false);
             this.groupProtection.PerformLayout();
+            this.groupImage.ResumeLayout(false);
+            this.groupImage.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.tbJpegQuality)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -341,5 +395,11 @@ namespace NAPS2.WinForms
         private System.Windows.Forms.LinkLabel linkPlaceholders;
         private System.Windows.Forms.TextBox txtDefaultFileName;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.GroupBox groupImage;
+        private System.Windows.Forms.Label lblImageCompressionInfo;
+        private System.Windows.Forms.TextBox txtJpegQuality;
+        private System.Windows.Forms.TrackBar tbJpegQuality;
+        private System.Windows.Forms.CheckBox cbCompressImagePdf;
+        private System.Windows.Forms.Label lbCompressImageQuality;
     }
 }

--- a/NAPS2.Core/WinForms/FPdfSettings.cs
+++ b/NAPS2.Core/WinForms/FPdfSettings.cs
@@ -5,6 +5,7 @@
     Copyright (C) 2009       Pavel Sorejs
     Copyright (C) 2012       Michael Adams
     Copyright (C) 2013       Peter De Leeuw
+    Copyright (C) 2015       Luca De Petrillo
     Copyright (C) 2012-2015  Ben Olden-Cooligan
 
     This program is free software; you can redistribute it and/or
@@ -24,6 +25,7 @@ using System.Linq;
 using System.Windows.Forms;
 using NAPS2.Config;
 using NAPS2.ImportExport.Pdf;
+using System.Globalization;
 
 namespace NAPS2.WinForms
 {
@@ -42,11 +44,11 @@ namespace NAPS2.WinForms
         protected override void OnLoad(object sender, EventArgs e)
         {
             new LayoutManager(this)
-                .Bind(btnOK, btnCancel, cbShowOwnerPassword, cbShowUserPassword)
+                .Bind(btnOK, btnCancel, cbShowOwnerPassword, cbShowUserPassword, txtJpegQuality)
                     .RightToForm()
-                .Bind(groupMetadata, groupProtection)
+                .Bind(groupMetadata, groupImage, groupProtection)
                     .WidthToForm()
-                .Bind(txtDefaultFileName, txtTitle, txtAuthor, txtSubject, txtKeywords, txtOwnerPassword, txtUserPassword)
+                .Bind(txtDefaultFileName, txtTitle, txtAuthor, txtSubject, txtKeywords, txtOwnerPassword, txtUserPassword, tbJpegQuality, lblImageCompressionInfo)
                     .WidthToForm()
                 .Activate();
 
@@ -73,6 +75,9 @@ namespace NAPS2.WinForms
             cbAllowFullQualityPrinting.Checked = pdfSettings.Encryption.AllowFullQualityPrinting;
             cbAllowDocumentModification.Checked = pdfSettings.Encryption.AllowDocumentModification;
             cbAllowPrinting.Checked = pdfSettings.Encryption.AllowPrinting;
+
+            cbCompressImagePdf.Checked = pdfSettings.ImageSettings.CompressImages;
+            txtJpegQuality.Text = pdfSettings.ImageSettings.JpegQuality.ToString(CultureInfo.InvariantCulture);
         }
 
         private void UpdateEnabled()
@@ -84,6 +89,10 @@ namespace NAPS2.WinForms
                 cbAllowContentCopying.Enabled = cbAllowContentCopyingForAccessibility.Enabled =
                     cbAllowDocumentAssembly.Enabled = cbAllowDocumentModification.Enabled = cbAllowFormFilling.Enabled =
                         cbAllowFullQualityPrinting.Enabled = cbAllowPrinting.Enabled = encrypt;
+
+            bool compressImage = cbCompressImagePdf.Checked;
+            txtJpegQuality.Enabled = tbJpegQuality.Enabled = lbCompressImageQuality.Enabled = 
+                lblImageCompressionInfo.Enabled =  compressImage;
         }
 
         private void btnOK_Click(object sender, EventArgs e)
@@ -97,6 +106,11 @@ namespace NAPS2.WinForms
                     Author = txtAuthor.Text,
                     Subject = txtSubject.Text,
                     Keywords = txtKeywords.Text
+                },
+                ImageSettings = 
+                {
+                    CompressImages = cbCompressImagePdf.Checked,
+                    JpegQuality = tbJpegQuality.Value
                 },
                 Encryption =
                 {
@@ -156,6 +170,28 @@ namespace NAPS2.WinForms
             {
                 txtDefaultFileName.Text = form.FileName;
             }
+        }
+
+        private void tbJpegQuality_Scroll(object sender, EventArgs e)
+        {
+            txtJpegQuality.Text = tbJpegQuality.Value.ToString("G");
+        }
+
+        private void txtJpegQuality_TextChanged(object sender, EventArgs e)
+        {
+            int value;
+            if (int.TryParse(txtJpegQuality.Text, out value))
+            {
+                if (value >= tbJpegQuality.Minimum && value <= tbJpegQuality.Maximum)
+                {
+                    tbJpegQuality.Value = value;
+                }
+            }
+        }
+
+        private void cbCompressImagePdf_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateEnabled();
         }
     }
 }

--- a/NAPS2.Core/WinForms/FPdfSettings.resx
+++ b/NAPS2.Core/WinForms/FPdfSettings.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnOK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 584</value>
+    <value>264, 703</value>
   </data>
   <data name="btnOK.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -145,13 +145,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="btnCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>345, 584</value>
+    <value>345, 703</value>
   </data>
   <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -172,7 +172,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <metadata name="ilProfileIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -403,7 +403,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupMetadata.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="cbShowUserPassword.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -823,7 +823,7 @@
     <value>14</value>
   </data>
   <data name="groupProtection.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 253</value>
+    <value>12, 372</value>
   </data>
   <data name="groupProtection.Size" type="System.Drawing.Size, System.Drawing">
     <value>408, 304</value>
@@ -844,13 +844,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupProtection.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="cbRememberSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="cbRememberSettings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="cbRememberSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 563</value>
+    <value>12, 682</value>
   </data>
   <data name="cbRememberSettings.Size" type="System.Drawing.Size, System.Drawing">
     <value>145, 17</value>
@@ -871,10 +874,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbRememberSettings.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="btnRestoreDefaults.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 584</value>
+    <value>12, 703</value>
   </data>
   <data name="btnRestoreDefaults.Size" type="System.Drawing.Size, System.Drawing">
     <value>145, 23</value>
@@ -895,7 +898,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRestoreDefaults.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="linkPlaceholders.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -925,7 +928,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;linkPlaceholders.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="txtDefaultFileName.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 25</value>
@@ -946,7 +949,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtDefaultFileName.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -976,7 +979,163 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lbCompressImageQuality.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lbCompressImageQuality.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lbCompressImageQuality.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 35</value>
+  </data>
+  <data name="lbCompressImageQuality.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 13</value>
+  </data>
+  <data name="lbCompressImageQuality.TabIndex" type="System.Int32, mscorlib">
+    <value>39</value>
+  </data>
+  <data name="lbCompressImageQuality.Text" xml:space="preserve">
+    <value>Jpeg Quality</value>
+  </data>
+  <data name="&gt;&gt;lbCompressImageQuality.Name" xml:space="preserve">
+    <value>lbCompressImageQuality</value>
+  </data>
+  <data name="&gt;&gt;lbCompressImageQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbCompressImageQuality.Parent" xml:space="preserve">
+    <value>groupImage</value>
+  </data>
+  <data name="&gt;&gt;lbCompressImageQuality.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbCompressImagePdf.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCompressImagePdf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 15</value>
+  </data>
+  <data name="cbCompressImagePdf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>108, 17</value>
+  </data>
+  <data name="cbCompressImagePdf.TabIndex" type="System.Int32, mscorlib">
+    <value>38</value>
+  </data>
+  <data name="cbCompressImagePdf.Text" xml:space="preserve">
+    <value>Compress images</value>
+  </data>
+  <data name="&gt;&gt;cbCompressImagePdf.Name" xml:space="preserve">
+    <value>cbCompressImagePdf</value>
+  </data>
+  <data name="&gt;&gt;cbCompressImagePdf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCompressImagePdf.Parent" xml:space="preserve">
+    <value>groupImage</value>
+  </data>
+  <data name="&gt;&gt;cbCompressImagePdf.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblImageCompressionInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblImageCompressionInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 83</value>
+  </data>
+  <data name="lblImageCompressionInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>396, 27</value>
+  </data>
+  <data name="lblImageCompressionInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
+  </data>
+  <data name="lblImageCompressionInfo.Text" xml:space="preserve">
+    <value>Images are compressed if Maximum Quality profile option is used.</value>
+  </data>
+  <data name="&gt;&gt;lblImageCompressionInfo.Name" xml:space="preserve">
+    <value>lblImageCompressionInfo</value>
+  </data>
+  <data name="&gt;&gt;lblImageCompressionInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageCompressionInfo.Parent" xml:space="preserve">
+    <value>groupImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageCompressionInfo.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="txtJpegQuality.Location" type="System.Drawing.Point, System.Drawing">
+    <value>364, 51</value>
+  </data>
+  <data name="txtJpegQuality.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 20</value>
+  </data>
+  <data name="txtJpegQuality.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="txtJpegQuality.Text" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtJpegQuality.Name" xml:space="preserve">
+    <value>txtJpegQuality</value>
+  </data>
+  <data name="&gt;&gt;txtJpegQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtJpegQuality.Parent" xml:space="preserve">
+    <value>groupImage</value>
+  </data>
+  <data name="&gt;&gt;txtJpegQuality.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tbJpegQuality.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tbJpegQuality.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 51</value>
+  </data>
+  <data name="tbJpegQuality.Size" type="System.Drawing.Size, System.Drawing">
+    <value>352, 45</value>
+  </data>
+  <data name="tbJpegQuality.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
+  </data>
+  <data name="&gt;&gt;tbJpegQuality.Name" xml:space="preserve">
+    <value>tbJpegQuality</value>
+  </data>
+  <data name="&gt;&gt;tbJpegQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbJpegQuality.Parent" xml:space="preserve">
+    <value>groupImage</value>
+  </data>
+  <data name="&gt;&gt;tbJpegQuality.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="groupImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 253</value>
+  </data>
+  <data name="groupImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>408, 113</value>
+  </data>
+  <data name="groupImage.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="groupImage.Text" xml:space="preserve">
+    <value>Image compression</value>
+  </data>
+  <data name="&gt;&gt;groupImage.Name" xml:space="preserve">
+    <value>groupImage</value>
+  </data>
+  <data name="&gt;&gt;groupImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupImage.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupImage.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -985,7 +1144,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>432, 619</value>
+    <value>432, 738</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1012,10 +1171,10 @@
 </value>
   </data>
   <data name="$this.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>600, 658</value>
+    <value>600, 777</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>400, 658</value>
+    <value>400, 777</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>PDF Settings</value>
@@ -1024,12 +1183,12 @@
     <value>ilProfileIcons</value>
   </data>
   <data name="&gt;&gt;ilProfileIcons.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.ILProfileIcons, NAPS2.Core, Version=4.0.3.7448, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.ILProfileIcons, NAPS2.Core, Version=4.1.1.22191, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>FPdfSettings</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=4.0.3.7448, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=4.1.1.22191, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
Images are compressed only if they are "High Quality" (Maximum Quality profile option enabled for scan or imported from a lossless format from file), and only if the compressed image is smaller than the original one.

The new option is disabled by default, in order to maintain the original behavior.
