### PR TITLE
Add method to drivers to get a list of scaning devices.

### DIFF
--- a/NAPS2.Core/Scan/IScanDriver.cs
+++ b/NAPS2.Core/Scan/IScanDriver.cs
@@ -75,5 +75,11 @@ namespace NAPS2.Scan
         /// <exception cref="ScanDriverException">Throws a ScanDriverException if an error occurs while scanning.</exception>
         /// /// <exception cref="InvalidOperationException">Throws an InvalidOperationException if ScanProfile or DialogParent has not been set.</exception>
         IEnumerable<ScannedImage> Scan();
+
+        /// <summary>
+        /// Get the list of available scaning devices.
+        /// </summary>
+        /// <returns>A list of ScanDevice</returns>
+        IEnumerable<ScanDevice> GetDeviceList();
     }
 }

--- a/NAPS2.Core/Scan/ScanDriverBase.cs
+++ b/NAPS2.Core/Scan/ScanDriverBase.cs
@@ -94,5 +94,9 @@ namespace NAPS2.Scan
         }
 
         protected abstract IEnumerable<ScannedImage> ScanInternal();
+
+
+        public abstract IEnumerable<ScanDevice> GetDeviceList();
+
     }
 }

--- a/NAPS2.Core/Scan/Stub/StubScanDriver.cs
+++ b/NAPS2.Core/Scan/Stub/StubScanDriver.cs
@@ -59,6 +59,11 @@ namespace NAPS2.Scan.Stub
             }
         }
 
+        public IEnumerable<ScanDevice> GetDeviceList()
+        {
+            return new List<ScanDevice> { new ScanDevice("test", "Test Scanner") };
+        }
+
         private int ImageCount
         {
             get

--- a/NAPS2.Core/Scan/Twain/TwainScanDriver.cs
+++ b/NAPS2.Core/Scan/Twain/TwainScanDriver.cs
@@ -81,6 +81,12 @@ namespace NAPS2.Scan.Twain
             return twainWrapper.GetDeviceList(twainImpl);
         }
 
+        public override IEnumerable<ScanDevice> GetDeviceList()
+        {
+            var twainImpl = ScanProfile != null ? ScanProfile.TwainImpl : TwainImpl.Default;
+            return GetDeviceList(twainImpl);
+        }
+
         protected override IEnumerable<ScannedImage> ScanInternal()
         {
             if (UseHostService)

--- a/NAPS2.Core/Scan/Wia/WiaApi.cs
+++ b/NAPS2.Core/Scan/Wia/WiaApi.cs
@@ -97,6 +97,18 @@ namespace NAPS2.Scan.Wia
 
         #region Device/Item Management
 
+
+        public static IEnumerable<ScanDevice> GetDeviceList()
+        {
+            List<ScanDevice> devices = new List<ScanDevice>();
+            WIA.DeviceManager manager = new WIA.DeviceManager();
+            foreach (WIA.DeviceInfo info in manager.DeviceInfos)
+            {
+                devices.Add(new ScanDevice(info.DeviceID, GetDeviceName(info.DeviceID)));
+            }
+            return devices;
+        }
+
         public static ScanDevice PromptForDevice()
         {
             var wiaCommonDialog = new CommonDialogClass();

--- a/NAPS2.Core/Scan/Wia/WiaScanDriver.cs
+++ b/NAPS2.Core/Scan/Wia/WiaScanDriver.cs
@@ -57,6 +57,11 @@ namespace NAPS2.Scan.Wia
             return WiaApi.PromptForDevice();
         }
 
+        public override IEnumerable<ScanDevice> GetDeviceList()
+        {
+            return WiaApi.GetDeviceList();
+        }
+
         protected override IEnumerable<ScannedImage> ScanInternal()
         {
             using (var eventLoop = new WiaBackgroundEventLoop(ScanProfile, ScanDevice, threadFactory))

--- a/NAPS2.Core/WinForms/FEditProfile.cs
+++ b/NAPS2.Core/WinForms/FEditProfile.cs
@@ -229,6 +229,9 @@ namespace NAPS2.WinForms
         private void ChooseDevice(string driverName)
         {
             var driver = driverFactory.Create(driverName);
+
+            
+
             try
             {
                 driver.DialogParent = this;

--- a/NAPS2/NAPS2.csproj
+++ b/NAPS2/NAPS2.csproj
@@ -204,7 +204,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>
-    <PostBuildEvent>call "$(VS110COMNTOOLS)..\tools\vsvars32.bat"
+    <PostBuildEvent>call "D:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\vsvars32.bat"
 editbin /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
I'm using NCAPS2 as part of other application that offers scanning capabilities, however we already have some UI to deal with the process, the added method will help us to reuse the existing work.

IMO this will help using NCAPS not only as a scan application, but also as a library for other applications (similar to Image Components, and others)

I hope you find value in the PR, 

Thank you for this great work!