### PR TITLE
Update nl.po

### DIFF
--- a/NAPS2.Core/Lang/po/nl.po
+++ b/NAPS2.Core/Lang/po/nl.po
@@ -131,11 +131,11 @@ msgstr "Afdrukken toestaan"
 # This is a hard one to translate. I'll have to see it in context to confirm this is the proper translation.
 #: FDesktop.resx$tsAltDeinterleave.Text$Message
 msgid "Alternate Deinterleave"
-msgstr "Afwisselend terug tussenvoegen"
+msgstr "Alternatief terug tussenvoegen"
 
 #: FDesktop.resx$tsAltInterleave.Text$Message
 msgid "Alternate Interleave"
-msgstr "Afwisselend tussenvoegen"
+msgstr "Alternatief afwisselend tussenvoegen"
 
 #: MiscResources.resx$AutoSaveError$Message
 msgid "An error occurred when trying to auto save"


### PR DESCRIPTION
Deinterleave and altdeinterleave were the same.

"Interleave" -> "Afwisselend tussenvoegen"
"Deinterleave" -> "Terug tussenvoegen"

"Alternate Interleave" -> "Alternatief afwisselend tussenvoegen"
"Alternate Deinterleave" -> "Alternatief terug tussenvoegen"

On other request: would it be an idea to show a tooltip when the mouse hovers above the choices and showing what you have in your manual like this:    "1,3,5,2,4,6" -> "1,2,3,4,5,6"  (nobody really knows what will happen without an example ;)

Thanks for your great product!