### PR TITLE
Fix OCR download error due to system/input locale mismatch

### DIFF
--- a/NAPS2.Core/Dependencies/DownloadFormat.cs
+++ b/NAPS2.Core/Dependencies/DownloadFormat.cs
@@ -61,6 +61,13 @@ namespace NAPS2.Dependencies
 
             private static void Extract(string zipFilePath, string outDir)
             {
+                if(ZipConstants.DefaultCodePage == 1)
+                {
+                    // ZipFile ctor throws if code page is 1 (on multi-locale system)
+                    // see: icsharpcode/SharpZipLib#195
+                    ZipConstants.DefaultCodePage = 850;
+                }
+
                 using (var zip = new ZipFile(zipFilePath))
                 {
                     foreach (ZipEntry entry in zip)


### PR DESCRIPTION
Cirumvents an issue where the OCR file download fails when the system and input locale is not identical. This is a known SharpZipLib issue (see icsharpcode/SharpZipLib#195), fix is the same as mibe/Srtm2Osm@ad4c2e50dd023d93a992b37516743da72728d338.

This was also reported by a user on SourceForge: https://sourceforge.net/p/naps2/tickets/685