### PR TITLE
Write AppVersion to Registry

### DIFF
--- a/NAPS2/Setup/setup.iss
+++ b/NAPS2/Setup/setup.iss
@@ -6,6 +6,7 @@
 [Setup]
 AppName=NAPS2 (Not Another PDF Scanner 2)
 AppVerName=NAPS2 {#AppVersion}
+AppVersion={#AppVersion}
 AppPublisher=Ben Olden-Cooligan
 AppPublisherURL=http://www.sourceforge.net/projects/naps2
 AppSupportURL=http://www.sourceforge.net/projects/naps2


### PR DESCRIPTION
This sets the AppVersion to be written to the registry so that Windows can report the version through Control Panel and other tools like Winget

* Resolves microsoft/winget-pkgs#90081