### PR TITLE
Limit number of tesseract processes

### DIFF
--- a/NAPS2.Sdk/Ocr/OcrRequestQueue.cs
+++ b/NAPS2.Sdk/Ocr/OcrRequestQueue.cs
@@ -20,7 +20,7 @@ public class OcrRequestQueue
     /// Gets or sets the number of queue workers, which determines the maximum number of OCR requests that can process
     /// in parallel.
     /// </summary>
-    public int WorkerCount { get; init; } = Environment.ProcessorCount; 
+    public int WorkerCount { get; init; } = Environment.ProcessorCount;
 
     /// <summary>
     /// For testing. Adds a delay to the worker tasks to process requests.

--- a/NAPS2.Sdk/Ocr/OcrRequestQueue.cs
+++ b/NAPS2.Sdk/Ocr/OcrRequestQueue.cs
@@ -20,7 +20,7 @@ public class OcrRequestQueue
     /// Gets or sets the number of queue workers, which determines the maximum number of OCR requests that can process
     /// in parallel.
     /// </summary>
-    public int WorkerCount { get; init; } = Environment.ProcessorCount;
+    public int WorkerCount { get; init; } = Environment.ProcessorCount; 
 
     /// <summary>
     /// For testing. Adds a delay to the worker tasks to process requests.

--- a/NAPS2.Sdk/Ocr/TesseractOcrEngine.cs
+++ b/NAPS2.Sdk/Ocr/TesseractOcrEngine.cs
@@ -51,6 +51,8 @@ public class TesseractOcrEngine : IOcrEngine
                 logger.LogError("Couldn't start OCR process.");
                 return null;
             }
+            // to improve main window responsiveness:
+            tesseractProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
 
             var waitTasks = new List<Task>
             {


### PR DESCRIPTION
When using NAPS2 with a document scanner and automatic feeder, the current implementation launches too many tesseract processes, for the main application to react on paper jams or multiple feeds in a timely manner. 
Instead, one has to wait till the main window fetches the already scanned pages so that the twain driver retries the scan. Which is very annoying.