### PR TITLE
display the image number and total number in the thumbnail view 

### DIFF
--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
@@ -10,8 +10,6 @@ namespace NAPS2.EtoForms.WinForms;
 
 public class WinFormsListView<T> : IListView<T> where T : notnull
 {
-    private readonly Naps2Config _config;
-
     private static readonly Pen DefaultPen = new(Color.Black, 1);
     private static readonly Pen SelectionPen = new(Color.FromArgb(0x60, 0xa0, 0xe8), 3);
 
@@ -25,11 +23,12 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
 
     public WinFormsListView(ListViewBehavior<T> behavior)
     {
+        
         _behavior = behavior;
+        
         _view = behavior.ScrollOnDrag ? new DragScrollListView() : new ListView();
         _view.MultiSelect = behavior.MultiSelect;
 
-        _config = Naps2Config.Stub();
         if (_behavior.Checkboxes)
         {
             _view.View = View.List;
@@ -87,7 +86,8 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
         }
         else
         {
-            if (_config.Get(c => c.EnableThumbnailText))
+            //if (_config.Get(c => c.ShowPageNumbers))
+            if (_behavior.ShowPageNumbers)
                 height = ImageSize - 12;
             else
                 height = ImageSize;
@@ -96,7 +96,7 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
         var x = e.Bounds.Left + (e.Bounds.Width - width) / 2;
         var y = e.Bounds.Top + (e.Bounds.Height - height) / 2;
         e.Graphics.DrawImage(image, new Rectangle(x, y, width, height));
-        if (_config.Get(c => c.EnableThumbnailText)) 
+        if (_behavior.ShowPageNumbers) 
         { 
             // Draw the text below the image
             //var draw = _config.Get(c => c.EnableThumbnailText);
@@ -108,7 +108,7 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
             SolidBrush drawBrush = new SolidBrush(Color.Black);
 
             // Create point 
-            float x1 = x + width/2;
+            float x1 = x + width / 2;
             float y1 = y + height + 6;
 
             // Set format of string.

--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
@@ -86,7 +86,6 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
         }
         else
         {
-            //if (_config.Get(c => c.ShowPageNumbers))
             if (_behavior.ShowPageNumbers)
                 height = ImageSize - 12;
             else
@@ -99,7 +98,6 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
         if (_behavior.ShowPageNumbers) 
         { 
             // Draw the text below the image
-            //var draw = _config.Get(c => c.EnableThumbnailText);
             // Create string to draw.
             String drawString = (e.ItemIndex+1).ToString() + " / "+_view.Items.Count.ToString(); 
 

--- a/NAPS2.Lib/Config/CommonConfig.cs
+++ b/NAPS2.Lib/Config/CommonConfig.cs
@@ -166,4 +166,8 @@ public class CommonConfig
 
     [Common]
     public bool EnableDebugLogging { get; set; }
+    
+    [User]
+    public bool EnableThumbnailText { get; set; }
+
 }

--- a/NAPS2.Lib/Config/CommonConfig.cs
+++ b/NAPS2.Lib/Config/CommonConfig.cs
@@ -168,6 +168,6 @@ public class CommonConfig
     public bool EnableDebugLogging { get; set; }
     
     [User]
-    public bool EnableThumbnailText { get; set; }
+    public bool ShowPageNumbers { get; set; }
 
 }

--- a/NAPS2.Lib/Config/InternalDefaults.cs
+++ b/NAPS2.Lib/Config/InternalDefaults.cs
@@ -53,6 +53,7 @@ public static class InternalDefaults
             ThumbnailSize = ThumbnailSizes.DEFAULT_SIZE,
             DesktopToolStripDock = DockStyle.Top,
             EventLogging = EventType.None,
+            EnableThumbnailText = false,
             PdfSettings = new PdfSettings
             {
                 Metadata = new PdfMetadata

--- a/NAPS2.Lib/Config/InternalDefaults.cs
+++ b/NAPS2.Lib/Config/InternalDefaults.cs
@@ -53,7 +53,7 @@ public static class InternalDefaults
             ThumbnailSize = ThumbnailSizes.DEFAULT_SIZE,
             DesktopToolStripDock = DockStyle.Top,
             EventLogging = EventType.None,
-            EnableThumbnailText = false,
+            ShowPageNumbers = false,
             PdfSettings = new PdfSettings
             {
                 Metadata = new PdfMetadata

--- a/NAPS2.Lib/EtoForms/Widgets/ImageListViewBehavior.cs
+++ b/NAPS2.Lib/EtoForms/Widgets/ImageListViewBehavior.cs
@@ -21,7 +21,7 @@ public class ImageListViewBehavior : ListViewBehavior<UiImage>
         ScrollOnDrag = true;
         UseHandCursor = true;
     }
-
+    public override string GetLabel(UiImage item) => item.DisplayName ?? "";
     public override Image GetImage(UiImage item, int imageSize)
     {
         return _thumbnailProvider.GetThumbnail(item, imageSize).ToEtoImage();

--- a/NAPS2.Lib/EtoForms/Widgets/ImageListViewBehavior.cs
+++ b/NAPS2.Lib/EtoForms/Widgets/ImageListViewBehavior.cs
@@ -22,7 +22,6 @@ public class ImageListViewBehavior : ListViewBehavior<UiImage>
         UseHandCursor = true;
         ShowPageNumbers = config.Get(c => c.ShowPageNumbers);
     }
-    //public override string GetLabel(UiImage item) => item.DisplayName ?? "";
     public override Image GetImage(UiImage item, int imageSize)
     {
         return _thumbnailProvider.GetThumbnail(item, imageSize).ToEtoImage();

--- a/NAPS2.Lib/EtoForms/Widgets/ImageListViewBehavior.cs
+++ b/NAPS2.Lib/EtoForms/Widgets/ImageListViewBehavior.cs
@@ -11,7 +11,7 @@ public class ImageListViewBehavior : ListViewBehavior<UiImage>
     private readonly ImageTransfer _imageTransfer;
 
     public ImageListViewBehavior(UiThumbnailProvider thumbnailProvider, ImageTransfer imageTransfer,
-        ColorScheme colorScheme)
+        ColorScheme colorScheme, Naps2Config config)
     {
         _thumbnailProvider = thumbnailProvider;
         _imageTransfer = imageTransfer;
@@ -20,8 +20,9 @@ public class ImageListViewBehavior : ListViewBehavior<UiImage>
         ShowLabels = false;
         ScrollOnDrag = true;
         UseHandCursor = true;
+        ShowPageNumbers = config.Get(c => c.ShowPageNumbers);
     }
-    public override string GetLabel(UiImage item) => item.DisplayName ?? "";
+    //public override string GetLabel(UiImage item) => item.DisplayName ?? "";
     public override Image GetImage(UiImage item, int imageSize)
     {
         return _thumbnailProvider.GetThumbnail(item, imageSize).ToEtoImage();

--- a/NAPS2.Lib/EtoForms/Widgets/ListViewBehavior.cs
+++ b/NAPS2.Lib/EtoForms/Widgets/ListViewBehavior.cs
@@ -11,6 +11,8 @@ public abstract class ListViewBehavior<T> where T : notnull
         
     public bool ShowLabels { get; protected set; }
 
+    public bool ShowPageNumbers { get; protected set; }
+
     public bool ScrollOnDrag { get; protected set; }
 
     public bool UseHandCursor { get; protected set; }

--- a/NAPS2.Lib/Images/UiImage.cs
+++ b/NAPS2.Lib/Images/UiImage.cs
@@ -177,4 +177,6 @@ public class UiImage : IDisposable
             return new ImageRenderState(_processedImage.GetWeakReference(), _thumbnailTransformState, _thumbnail, this);
         }
     }
+
+    public string DisplayName { get; set; } = "";
 }

--- a/NAPS2.Lib/Images/UiImage.cs
+++ b/NAPS2.Lib/Images/UiImage.cs
@@ -178,5 +178,4 @@ public class UiImage : IDisposable
         }
     }
 
-    public string DisplayName { get; set; } = "";
 }


### PR DESCRIPTION
Config of the feature is disabled by default. Windows only for the moment.
Here what it's look like when enabled on Windows:
![image](https://user-images.githubusercontent.com/13395943/236652535-9c2dfff1-6891-40b7-a8f1-9182c14b8bc2.png)
