### PR TITLE
Replace WebClient with HttpClient

### DIFF
--- a/NAPS2.App.Tests/NAPS2.App.Tests.csproj
+++ b/NAPS2.App.Tests/NAPS2.App.Tests.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="Moq" Version="4.18.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>
 

--- a/NAPS2.Lib.Tests/Dependencies/DownloadControllerTests.cs
+++ b/NAPS2.Lib.Tests/Dependencies/DownloadControllerTests.cs
@@ -1,0 +1,147 @@
+﻿using Moq;
+using NAPS2.Dependencies;
+using NAPS2.Sdk.Tests;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace NAPS2.Lib.Tests.Dependencies;
+
+public class DownloadControllerTests : ContextualTests
+{
+    private const string AnimalsSHA1 = "1739ff74f5d26f6c42d7a3fc438d615a93d38bd4";
+    private const string StockDogJpegSHA1 = "ca1f89964bdb345e97804784eefa49a00dbf7207";
+
+    private const string DummyValidUrl = "http://localhost/f.zip";
+    private const string DummyInvalidUrl = "http://localhost/g.zip";
+
+
+    private readonly MemoryStream _animalsZipStream = new(BinaryResources.animals);
+    private readonly MemoryStream _dogsGzipStream = new(BinaryResources.stock_dog_jpeg);
+    private readonly MockHttpMessageHandler _httpHandler = new();
+    private readonly Mock<IExternalComponent> _mockComponent = new();
+    private readonly DownloadController _controller;
+    private byte[] _downloadData;
+
+    public DownloadControllerTests()
+    {
+        _mockComponent.Setup(x => x.Install(It.IsAny<string>())).Callback((string p) => _downloadData = File.ReadAllBytes(p));
+        _controller = new(ScanningContext, _httpHandler.ToHttpClient());
+    }
+
+    public override void Dispose()
+    {
+        _animalsZipStream.Dispose();
+        _dogsGzipStream.Dispose();
+        base.Dispose();
+    }
+
+    [Fact]
+    public async void NoQueue()
+    {
+        MockHttpMessageHandler handler = new();
+        DownloadController controller = new(ScanningContext, handler.ToHttpClient());
+
+        var mockHandler = new Mock<EventHandler>();
+
+        controller.DownloadComplete += mockHandler.Object;
+        Assert.True(await controller.StartDownloadsAsync());
+
+        Assert.Equal(0, _httpHandler.GetMatchCount(_httpHandler.Fallback));
+        mockHandler.Verify(x => x(controller, EventArgs.Empty), Times.Once);
+    }
+
+    [Fact]
+    public async void NoUrl()
+    {
+        DownloadInfo info = new("", new List<DownloadMirror>(), 0, "0000000000000000000000000000000000000000", DownloadFormat.Gzip);
+
+        var mockHandler = new Mock<Action<string>>();
+
+        _controller.QueueFile(info, mockHandler.Object);
+
+        Assert.False(await _controller.StartDownloadsAsync());
+
+        Assert.Equal(0, _httpHandler.GetMatchCount(_httpHandler.Fallback));
+        mockHandler.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async void InvalidChecksum()
+    {
+        _httpHandler.Expect(DummyValidUrl).Respond("application/gzip", _dogsGzipStream);
+
+        var mockHandler = new Mock<EventHandler>();
+
+        _controller.DownloadError += mockHandler.Object;
+
+        _mockComponent.Setup(x => x.DownloadInfo).Returns(new DownloadInfo("temp.gz", new List<DownloadMirror>() { new DownloadMirror(DummyValidUrl) }, 0, "THIS IS NOT AN SHA1 AND WILL FAIL", DownloadFormat.Gzip));
+
+        _controller.QueueFile(_mockComponent.Object);
+        Assert.False(await _controller.StartDownloadsAsync());
+
+        Assert.Equal(0, _httpHandler.GetMatchCount(_httpHandler.Fallback));
+        mockHandler.Verify(x => x(_controller, EventArgs.Empty), Times.Once);
+        mockHandler.VerifyNoOtherCalls();
+        _mockComponent.VerifyGet(x => x.DownloadInfo);
+        _mockComponent.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async void InvalidMirrorsChecksum()
+    {
+        _mockComponent.Setup(x => x.DownloadInfo).Returns(new DownloadInfo("temp.gz", new List<DownloadMirror>() { new DownloadMirror(DummyInvalidUrl), new DownloadMirror(DummyValidUrl) }, 0, StockDogJpegSHA1, DownloadFormat.Gzip));
+
+        _httpHandler.Expect(DummyInvalidUrl).Respond("application/zip", _animalsZipStream);
+        _httpHandler.Expect(DummyValidUrl).Respond("application/gzip", _dogsGzipStream);
+
+        _controller.QueueFile(_mockComponent.Object);
+        Assert.True(await _controller.StartDownloadsAsync());
+
+        _mockComponent.VerifyGet(x => x.DownloadInfo);
+        _mockComponent.Verify(x => x.Install(It.Is((string p) => !string.IsNullOrWhiteSpace(p))));
+        _mockComponent.VerifyNoOtherCalls();
+        Assert.Equal(BinaryResources.stock_dog, _downloadData);
+
+        _httpHandler.VerifyNoOutstandingExpectation();
+        Assert.Equal(0, _httpHandler.GetMatchCount(_httpHandler.Fallback));
+    }
+
+    [Fact]
+    public async void Valid()
+    {
+        _mockComponent.Setup(x => x.DownloadInfo).Returns(new DownloadInfo("temp.gz", new List<DownloadMirror>() { new DownloadMirror(DummyValidUrl) }, 0, StockDogJpegSHA1, DownloadFormat.Gzip));
+
+        _httpHandler.Expect(DummyValidUrl).Respond("application/gzip", _dogsGzipStream);
+
+        _controller.QueueFile(_mockComponent.Object);
+        Assert.True(await _controller.StartDownloadsAsync());
+
+        _mockComponent.VerifyGet(x => x.DownloadInfo);
+        _mockComponent.Verify(x => x.Install(It.Is((string p) => !string.IsNullOrWhiteSpace(p))));
+        _mockComponent.VerifyNoOtherCalls();
+        Assert.Equal(BinaryResources.stock_dog, _downloadData);
+
+        _httpHandler.VerifyNoOutstandingExpectation();
+        Assert.Equal(0, _httpHandler.GetMatchCount(_httpHandler.Fallback));
+    }
+
+    [Fact]
+    public async void ValidUsingMirrorUrl()
+    {
+        _mockComponent.Setup(x => x.DownloadInfo).Returns(new DownloadInfo("temp.gz", new List<DownloadMirror>() { new DownloadMirror(DummyInvalidUrl), new DownloadMirror(DummyValidUrl) }, 0, StockDogJpegSHA1, DownloadFormat.Gzip));
+
+        _httpHandler.Expect(DummyInvalidUrl);
+        _httpHandler.Expect(DummyValidUrl).Respond("application/gzip", _dogsGzipStream);
+
+        _controller.QueueFile(_mockComponent.Object);
+        Assert.True(await _controller.StartDownloadsAsync());
+
+        _mockComponent.VerifyGet(x => x.DownloadInfo);
+        _mockComponent.Verify(x => x.Install(It.Is((string p) => !string.IsNullOrWhiteSpace(p))));
+        _mockComponent.VerifyNoOtherCalls();
+        Assert.Equal(BinaryResources.stock_dog, _downloadData);
+
+        _httpHandler.VerifyNoOutstandingExpectation();
+        Assert.Equal(0, _httpHandler.GetMatchCount(_httpHandler.Fallback));
+    }
+}

--- a/NAPS2.Lib.Tests/Dependencies/DownloadFormatTests.cs
+++ b/NAPS2.Lib.Tests/Dependencies/DownloadFormatTests.cs
@@ -10,10 +10,12 @@ public class DownloadFormatTests : ContextualTests
     public void Gzip()
     {
         var path = Path.Combine(FolderPath, "f.gz");
-        var gzData = BinaryResources.stock_dog_jpeg;
-        File.WriteAllBytes(path, gzData);
 
-        var extractedPath = DownloadFormat.Gzip.Prepare(path);
+        string extractedPath;
+        using (MemoryStream stream = new(BinaryResources.stock_dog_jpeg))
+        {
+            extractedPath = DownloadFormat.Gzip.Prepare(stream, path);
+        }
 
         var expectedDog = BinaryResources.stock_dog;
         Assert.Equal(expectedDog, File.ReadAllBytes(extractedPath));
@@ -23,10 +25,12 @@ public class DownloadFormatTests : ContextualTests
     public void Zip()
     {
         var path = Path.Combine(FolderPath, "f.zip");
-        var zipData = BinaryResources.animals;
-        File.WriteAllBytes(path, zipData);
 
-        var extractedPath = DownloadFormat.Zip.Prepare(path);
+        string extractedPath;
+        using (MemoryStream stream = new(BinaryResources.animals))
+        {
+            extractedPath = DownloadFormat.Zip.Prepare(stream, path);
+        }
 
         var dogPath = Path.Combine(extractedPath, "animals/dogs/stock-dog.jpeg");
         var catPath = Path.Combine(extractedPath, "animals/cats/stock-cat.jpeg");

--- a/NAPS2.Lib.Tests/NAPS2.Lib.Tests.csproj
+++ b/NAPS2.Lib.Tests/NAPS2.Lib.Tests.csproj
@@ -22,7 +22,8 @@
         <PackageReference Include="NAPS2.Tesseract.Binaries" Version="1.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="Moq" Version="4.18.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>
 

--- a/NAPS2.Lib/Automation/AutomatedScanning.cs
+++ b/NAPS2.Lib/Automation/AutomatedScanning.cs
@@ -202,8 +202,7 @@ public class AutomatedScanning
         {
             _errorOutput.DisplayError(MiscResources.FilesCouldNotBeDownloaded);
         };
-        downloadController.Start();
-        await downloadController.CompletionTask;
+        await downloadController.StartDownloadsAsync();
     }
 
     private void ReorderScannedImages()

--- a/NAPS2.Lib/Dependencies/DownloadController.cs
+++ b/NAPS2.Lib/Dependencies/DownloadController.cs
@@ -1,5 +1,4 @@
-using System.ComponentModel;
-using System.Net;
+using System.Net.Http;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using NAPS2.Scan;
@@ -11,25 +10,15 @@ public class DownloadController
     private readonly ScanningContext _scanningContext;
     private readonly ILogger _logger;
 
-    // TODO: Migrate to HttpClient
-#pragma warning disable SYSLIB0014
-    private readonly WebClient _client = new();
-#pragma warning restore SYSLIB0014
+    private static readonly HttpClient _client = new();
 
     private readonly List<QueueItem> _filesToDownload = new();
-    private readonly TaskCompletionSource<bool> _completionSource = new();
-    private int _urlIndex;
-    private bool _hasError;
     private bool _cancel;
 
     public DownloadController(ScanningContext scanningContext)
     {
         _scanningContext = scanningContext;
         _logger = scanningContext.Logger;
-        // TODO: Is this needed for net462?
-        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-        _client.DownloadFileCompleted += client_DownloadFileCompleted;
-        _client.DownloadProgressChanged += client_DownloadProgressChanged;
     }
 
     public int FilesDownloaded { get; private set; }
@@ -39,41 +28,6 @@ public class DownloadController
     public long CurrentFileSize { get; private set; }
 
     public long CurrentFileProgress { get; private set; }
-
-    public Task CompletionTask => _completionSource.Task;
-
-    void client_DownloadProgressChanged(object? sender, DownloadProgressChangedEventArgs e)
-    {
-        CurrentFileProgress = e.BytesReceived;
-        CurrentFileSize = e.TotalBytesToReceive;
-        DownloadProgress?.Invoke(this, EventArgs.Empty);
-    }
-
-    void client_DownloadFileCompleted(object? sender, AsyncCompletedEventArgs e)
-    {
-        var file = _filesToDownload[FilesDownloaded];
-        if (e.Error != null)
-        {
-            _hasError = true;
-            if (!_cancel)
-            {
-                _logger.LogError(e.Error, "Error downloading file: {FileName}", file.DownloadInfo.FileName);
-            }
-        }
-        else if (file.DownloadInfo.Sha1 != CalculateSha1(Path.Combine(file.TempFolder!, file.DownloadInfo.FileName)))
-        {
-            _hasError = true;
-            _logger.LogError("Error downloading file (invalid checksum): {FileName}", file.DownloadInfo.FileName);
-        }
-        else
-        {
-            FilesDownloaded++;
-        }
-        CurrentFileProgress = 0;
-        CurrentFileSize = 0;
-        DownloadProgress?.Invoke(this, EventArgs.Empty);
-        StartNextDownload();
-    }
 
     public void QueueFile(DownloadInfo downloadInfo, Action<string> fileCallback)
     {
@@ -88,7 +42,7 @@ public class DownloadController
     public void Stop()
     {
         _cancel = true;
-        _client.CancelAsync();
+        _client.CancelPendingRequests();
     }
 
     public event EventHandler? DownloadError;
@@ -97,63 +51,116 @@ public class DownloadController
 
     public event EventHandler? DownloadProgress;
 
-    private void StartNextDownload()
+    private async Task<MemoryStream?> TryDownloadFromUrlAsync(string filename, string url)
     {
-        if (_hasError)
+        CurrentFileProgress = 0;
+        CurrentFileSize = 0;
+        DownloadProgress?.Invoke(this, EventArgs.Empty);
+        try
         {
-            var prev = _filesToDownload[FilesDownloaded];
-            Directory.Delete(prev.TempFolder!, true);
-            if (_cancel)
+            var response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+            CurrentFileSize = response.Content.Headers.ContentLength.GetValueOrDefault();
+
+            using var contentStream = await response.Content.ReadAsStreamAsync();
+
+            var result = new MemoryStream();
+            long previousLength;
+            byte[] buffer = new byte[1024 * 40];
+            do
             {
-                return;
+                previousLength = result.Length;
+                int length = await contentStream.ReadAsync(buffer, 0, buffer.Length);
+                if (length > 0)
+                {
+                    result.Write(buffer, 0, length);
+                    CurrentFileProgress = result.Length;
+                    DownloadProgress?.Invoke(this, EventArgs.Empty);
+                }
+                if (_cancel)
+                {
+                    throw new OperationCanceledException();
+                }
             }
-            // Retry if possible
-            _urlIndex++;
-            _hasError = false;
+            while (previousLength < result.Length);
+            return result;
         }
-        else
+        catch (OperationCanceledException)
         {
-            _urlIndex = 0;
+            throw;
         }
-        if (FilesDownloaded > 0 && _urlIndex == 0)
+        catch (Exception ex)
         {
-            var prev = _filesToDownload[FilesDownloaded - 1];
-            var filePath = Path.Combine(prev.TempFolder!, prev.DownloadInfo.FileName);
+            _logger.LogError(ex, "Error downloading file: {FileName}", filename);
+            return null;
+        }
+    }
+
+    private async Task<MemoryStream?> TryDownloadQueueItemAsync(QueueItem fileToDownload)
+    {
+        foreach (var url in fileToDownload.DownloadInfo.Urls)
+        {
+            var result = await TryDownloadFromUrlAsync(fileToDownload.DownloadInfo.FileName, url);
+            if (result != null)
+            {
+                result.Position = 0;
+                if (fileToDownload.DownloadInfo.Sha1 == CalculateSha1(result))
+                {
+                    return result;
+                }
+                _logger.LogError("Error downloading file (invalid checksum): {FileName}", fileToDownload.DownloadInfo.FileName);
+            }
+        }
+        return null;
+    }
+
+    private async Task<bool> InternalStartDownloadsAsync()
+    {
+        FilesDownloaded = 0;
+        foreach (var fileToDownload in _filesToDownload)
+        {
+            MemoryStream? result;
             try
             {
-                var preparedFilePath = prev.DownloadInfo.Format.Prepare(filePath);
-                prev.FileCallback(preparedFilePath);
+                result = await TryDownloadQueueItemAsync(fileToDownload);
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+
+            if (result == null)
+            {
+                DownloadComplete?.Invoke(this, EventArgs.Empty);
+                DownloadError?.Invoke(this, EventArgs.Empty);
+                return false;
+            }
+
+            fileToDownload.TempFolder = Path.Combine(_scanningContext.TempFolderPath, Path.GetRandomFileName());
+            Directory.CreateDirectory(fileToDownload.TempFolder);
+            string p = Path.Combine(fileToDownload.TempFolder, fileToDownload.DownloadInfo.FileName);
+            try
+            {
+                result.Position = 0;
+                var preparedFilePath = fileToDownload.DownloadInfo.Format.Prepare(result, p);
+                fileToDownload.FileCallback(preparedFilePath);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error preparing downloaded file");
                 DownloadError?.Invoke(this, EventArgs.Empty);
             }
-            Directory.Delete(prev.TempFolder!, true);
+            FilesDownloaded++;
+            Directory.Delete(fileToDownload.TempFolder, true);
         }
-        if (FilesDownloaded >= _filesToDownload.Count)
-        {
-            DownloadComplete?.Invoke(this, EventArgs.Empty);
-            _completionSource.SetResult(true);
-            return;
-        }
-        if (_urlIndex >= _filesToDownload[FilesDownloaded].DownloadInfo.Urls.Count)
-        {
-            DownloadComplete?.Invoke(this, EventArgs.Empty);
-            _completionSource.SetResult(false);
-            DownloadError?.Invoke(this, EventArgs.Empty);
-            return;
-        }
-        var next = _filesToDownload[FilesDownloaded];
-        next.TempFolder = Path.Combine(_scanningContext.TempFolderPath, Path.GetRandomFileName());
-        Directory.CreateDirectory(next.TempFolder);
-        _client.DownloadFileAsync(new Uri(next.DownloadInfo.Urls[_urlIndex]), Path.Combine(next.TempFolder, next.DownloadInfo.FileName));
+
+        DownloadComplete?.Invoke(this, EventArgs.Empty);
+        return true;
     }
 
-    private string CalculateSha1(string filePath)
+    private string CalculateSha1(Stream stream)
     {
         using var sha = SHA1.Create();
-        using FileStream stream = File.OpenRead(filePath);
         byte[] checksum = sha.ComputeHash(stream);
         string str = BitConverter.ToString(checksum).Replace("-", String.Empty).ToLowerInvariant();
         return str;
@@ -168,9 +175,9 @@ public class DownloadController
         public required Action<string> FileCallback { get; set; }
     }
 
-    public void Start()
+    public async Task<bool> StartDownloadsAsync()
     {
         DownloadProgress?.Invoke(this, EventArgs.Empty);
-        StartNextDownload();
+        return await InternalStartDownloadsAsync();
     }
 }

--- a/NAPS2.Lib/Dependencies/DownloadController.cs
+++ b/NAPS2.Lib/Dependencies/DownloadController.cs
@@ -36,9 +36,9 @@ public class DownloadController
 
     public int TotalFiles => _filesToDownload.Count;
 
-    public double CurrentFileSize { get; private set; }
+    public long CurrentFileSize { get; private set; }
 
-    public double CurrentFileProgress { get; private set; }
+    public long CurrentFileProgress { get; private set; }
 
     public Task CompletionTask => _completionSource.Task;
 

--- a/NAPS2.Lib/Dependencies/DownloadController.cs
+++ b/NAPS2.Lib/Dependencies/DownloadController.cs
@@ -7,18 +7,20 @@ namespace NAPS2.Dependencies;
 
 public class DownloadController
 {
+    private static readonly HttpClient DefaultHttpClient = new();
+
     private readonly ScanningContext _scanningContext;
     private readonly ILogger _logger;
 
-    private static readonly HttpClient _client = new();
-
+    private readonly HttpClient _client;
     private readonly List<QueueItem> _filesToDownload = new();
     private bool _cancel;
 
-    public DownloadController(ScanningContext scanningContext)
+    public DownloadController(ScanningContext scanningContext, HttpClient? client = null)
     {
         _scanningContext = scanningContext;
         _logger = scanningContext.Logger;
+        _client = client ?? DefaultHttpClient;
     }
 
     public int FilesDownloaded { get; private set; }

--- a/NAPS2.Lib/Dependencies/DownloadController.cs
+++ b/NAPS2.Lib/Dependencies/DownloadController.cs
@@ -31,12 +31,12 @@ public class DownloadController
 
     public void QueueFile(DownloadInfo downloadInfo, Action<string> fileCallback)
     {
-        _filesToDownload.Add(new QueueItem { DownloadInfo = downloadInfo, FileCallback = fileCallback });
+        _filesToDownload.Add(new QueueItem(downloadInfo, fileCallback));
     }
 
     public void QueueFile(IExternalComponent component)
     {
-        _filesToDownload.Add(new QueueItem { DownloadInfo = component.DownloadInfo, FileCallback = component.Install });
+        _filesToDownload.Add(new QueueItem(component.DownloadInfo, component.Install));
     }
 
     public void Stop()
@@ -136,9 +136,9 @@ public class DownloadController
                 return false;
             }
 
-            fileToDownload.TempFolder = Path.Combine(_scanningContext.TempFolderPath, Path.GetRandomFileName());
-            Directory.CreateDirectory(fileToDownload.TempFolder);
-            string p = Path.Combine(fileToDownload.TempFolder, fileToDownload.DownloadInfo.FileName);
+            string tempFolder = Path.Combine(_scanningContext.TempFolderPath, Path.GetRandomFileName());
+            Directory.CreateDirectory(tempFolder);
+            string p = Path.Combine(tempFolder, fileToDownload.DownloadInfo.FileName);
             try
             {
                 result.Position = 0;
@@ -151,7 +151,7 @@ public class DownloadController
                 DownloadError?.Invoke(this, EventArgs.Empty);
             }
             FilesDownloaded++;
-            Directory.Delete(fileToDownload.TempFolder, true);
+            Directory.Delete(tempFolder, true);
         }
 
         DownloadComplete?.Invoke(this, EventArgs.Empty);
@@ -166,14 +166,7 @@ public class DownloadController
         return str;
     }
 
-    private class QueueItem
-    {
-        public required DownloadInfo DownloadInfo { get; set; }
-
-        public string? TempFolder { get; set; }
-
-        public required Action<string> FileCallback { get; set; }
-    }
+    private record QueueItem(DownloadInfo DownloadInfo, Action<string> FileCallback);
 
     public async Task<bool> StartDownloadsAsync()
     {

--- a/NAPS2.Lib/EtoForms/Ui/DownloadProgressForm.cs
+++ b/NAPS2.Lib/EtoForms/Ui/DownloadProgressForm.cs
@@ -51,7 +51,7 @@ public class DownloadProgressForm : EtoDialogBase
     protected override void OnLoad(EventArgs e)
     {
         base.OnLoad(e);
-        Controller.Start();
+        Controller.StartDownloadsAsync().AssertNoAwait();
     }
 
     private void OnDownloadProgress(object? sender, EventArgs e)

--- a/NAPS2.Lib/EtoForms/Ui/DownloadProgressForm.cs
+++ b/NAPS2.Lib/EtoForms/Ui/DownloadProgressForm.cs
@@ -62,7 +62,7 @@ public class DownloadProgressForm : EtoDialogBase
         var cTot = Controller.CurrentFileSize;
         _totalStatus.Text = string.Format(MiscResources.FilesProgressFormat, f, fTot);
         _totalProgressBar.MaxValue = fTot * 1000;
-        _totalProgressBar.Value = f * 1000 + (cTot == 0 ? 0 : (int)(c / cTot * 1000));
+        _totalProgressBar.Value = f * 1000 + (cTot == 0 ? 0 : (int)(c * 1e3 / cTot));
         _fileStatus.Text = string.Format(MiscResources.SizeProgress, (c / 1e6).ToString("f1"), (cTot / 1e6).ToString("f1"));
         if (c > 0)
         {


### PR DESCRIPTION
Hi, this replaces the `WebClient` usage in `DownloadController` with `HttpClient`. By doing so we can properly use `Task` and `async`/`await` and no longer use a deprecated component.

It downloads the file first into a `MemoryStream` instead of a temporary file and then only decompresses it into the temporary file/directory provided by the controller.