### PR TITLE
Improve custom label format

### DIFF
--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
@@ -12,6 +12,7 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
 {
     private static readonly Pen DefaultPen = new(Color.Black, 1);
     private static readonly Pen SelectionPen = new(Color.FromArgb(0x60, 0xa0, 0xe8), 3);
+    private static readonly StringFormat LabelFormat = new() { Alignment = StringAlignment.Center };
 
     private readonly ListView _view;
     private readonly Eto.Forms.Control _viewEtoControl;
@@ -97,16 +98,12 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
         {
             // Draw the text below the image
             string drawString = $"{e.ItemIndex + 1} / {_view.Items.Count}";
-            var drawFont = new Font("Arial", 10);
-            var drawBrush = new SolidBrush(Color.Black);
+            var drawBrush = Brushes.Black;
 
             float x1 = x + width / 2;
             float y1 = y + height + 6;
 
-            var drawFormat = new StringFormat();
-            drawFormat.Alignment = StringAlignment.Center;
-
-            e.Graphics.DrawString(drawString, drawFont, drawBrush, x1, y1, drawFormat);
+            e.Graphics.DrawString(drawString, _view.Font, drawBrush, x1, y1, LabelFormat);
         }
         // Draw border
         if (e.Item.Selected)

--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
@@ -137,7 +137,7 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
         // Draw border
         if (!e.Item.Selected)
         {
-            e.Graphics.DrawRectangle(DefaultPen, x, y, width, height);
+            e.Graphics.DrawRectangle(DefaultPen, x - 1, y - 1, width + 1, height + 1);
         }
     }
 

--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
@@ -11,8 +11,10 @@ namespace NAPS2.EtoForms.WinForms;
 public class WinFormsListView<T> : IListView<T> where T : notnull
 {
     private const int TextPadding = 6;
+    private const int SelectionPadding = 3;
     private static readonly Pen DefaultPen = new(Color.Black, 1);
-    private static readonly Pen SelectionPen = new(Color.FromArgb(0x60, 0xa0, 0xe8), 3);
+    private static readonly SolidBrush OutlineBrush = new(Color.FromArgb(0x60, 0xa0, 0xe8));
+    private static readonly SolidBrush SelectionBrush = new(Color.FromArgb(0xcc, 0xe8, 0xff));
     private static readonly StringFormat LabelFormat = new() { Alignment = StringAlignment.Center, Trimming = StringTrimming.EllipsisCharacter };
 
     private readonly ListView _view;
@@ -97,6 +99,26 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
 
         var x = e.Bounds.Left + (e.Bounds.Width - width) / 2;
         var y = e.Bounds.Top + (e.Bounds.Height - height - textOffset) / 2;
+
+        if (e.Item.Selected)
+        {
+            Size intTextSize = Size.Ceiling(textSize);
+
+            int selectionWidth = Math.Max(width, intTextSize.Width);
+            int selectionHeight = height + TextPadding + intTextSize.Height;
+
+            var selectionX = e.Bounds.Left + (e.Bounds.Width - width) / 2;
+
+            var selectionRect = new Rectangle(selectionX, y, selectionWidth, selectionHeight);
+            selectionRect.Inflate(SelectionPadding, SelectionPadding);
+
+            var outlineRect = selectionRect;
+            outlineRect.Inflate(1, 1);
+            e.Graphics.FillRectangle(OutlineBrush, outlineRect);
+
+            e.Graphics.FillRectangle(SelectionBrush, selectionRect);
+        }
+
         e.Graphics.DrawImage(image, new Rectangle(x, y, width, height));
         if (!string.IsNullOrEmpty(label))
         {
@@ -113,11 +135,7 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
             e.Graphics.DrawString(label, _view.Font, drawBrush, labelRect, LabelFormat);
         }
         // Draw border
-        if (e.Item.Selected)
-        {
-            e.Graphics.DrawRectangle(SelectionPen, x - 2, y - 2, width + 3, height + 3);
-        }
-        else
+        if (!e.Item.Selected)
         {
             e.Graphics.DrawRectangle(DefaultPen, x, y, width, height);
         }

--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsListView.cs
@@ -13,7 +13,7 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
     private const int TextPadding = 6;
     private static readonly Pen DefaultPen = new(Color.Black, 1);
     private static readonly Pen SelectionPen = new(Color.FromArgb(0x60, 0xa0, 0xe8), 3);
-    private static readonly StringFormat LabelFormat = new() { Alignment = StringAlignment.Center };
+    private static readonly StringFormat LabelFormat = new() { Alignment = StringAlignment.Center, Trimming = StringTrimming.EllipsisCharacter };
 
     private readonly ListView _view;
     private readonly Eto.Forms.Control _viewEtoControl;
@@ -79,11 +79,12 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
     {
         var image = ImageList.Get(e.Item);
         string? label = null;
+        SizeF textSize = SizeF.Empty;
         int textOffset = 0;
         if (_behavior.ShowPageNumbers)
         {
             label = $"{e.ItemIndex + 1} / {_view.Items.Count}";
-            SizeF textSize = e.Graphics.MeasureString(label, _view.Font);
+            textSize = e.Graphics.MeasureString(label, _view.Font);
             textOffset = (int)(textSize.Height + TextPadding);
         }
 
@@ -105,7 +106,11 @@ public class WinFormsListView<T> : IListView<T> where T : notnull
             float x1 = x + width / 2;
             float y1 = y + height + TextPadding;
 
-            e.Graphics.DrawString(label, _view.Font, drawBrush, x1, y1, LabelFormat);
+            RectangleF labelRect = new(x1, y1, 0, textSize.Height);
+            float maxLabelWidth = Math.Min(textSize.Width, e.Bounds.Width - 2 * TextPadding);
+            labelRect.Inflate(maxLabelWidth / 2, 0);
+
+            e.Graphics.DrawString(label, _view.Font, drawBrush, labelRect, LabelFormat);
         }
         // Draw border
         if (e.Item.Selected)


### PR DESCRIPTION
With #143 a label for the page number and total page count was added. This pull request improves a few things based on top of that change:

1. Added selection rectangle around the custom label.
2. It does not recreate the brush/font/format instances every time and only does this once.
3. Remove the text height from the available height, when determining the scale factor. Previously it justed removed the text height, when the image was higher than wide, but in certain cases (e.g. square images) this would push the text to low.