### PR TITLE
Create all directories in the default file path unless they already exists

### DIFF
--- a/NAPS2.Lib/ImportExport/ExportController.cs
+++ b/NAPS2.Lib/ImportExport/ExportController.cs
@@ -40,6 +40,7 @@ public class ExportController : IExportController
         if (_config.Get(c => c.PdfSettings.SkipSavePrompt) && Path.IsPathRooted(defaultFileName))
         {
             savePath = defaultFileName!;
+            Directory.CreateDirectory(Path.GetDirectoryName(savePath)!);
         }
         else
         {


### PR DESCRIPTION
Fixes #214 

Create all directories and subdirectories in the default file path unless they already exist.