### PR TITLE
Correct NASP2 to NAPS2

### DIFF
--- a/NAPS2.Lib/Lang/Resources/UiStrings.sk.resx
+++ b/NAPS2.Lib/Lang/Resources/UiStrings.sk.resx
@@ -778,7 +778,7 @@
     <value>Naozaj chcete prestať zdieľať {0}?</value>
   </data>
   <data name="ShareAsService" xml:space="preserve">
-    <value>Zdieľať aj keď je NASP2 zavretý</value>
+    <value>Zdieľať aj keď je NAPS2 zavretý</value>
   </data>
   <data name="MultipleLanguages" xml:space="preserve">
     <value>Viacero jazykov...</value>

--- a/NAPS2.Lib/Lang/po/sk.po
+++ b/NAPS2.Lib/Lang/po/sk.po
@@ -1401,7 +1401,7 @@ msgstr "Zdieľať"
 
 #: UiStrings.resx$ShareAsService$Message
 msgid "Share even when NAPS2 is closed"
-msgstr "Zdieľať aj keď je NASP2 zavretý"
+msgstr "Zdieľať aj keď je NAPS2 zavretý"
 
 #: UiStrings.resx$SharedDeviceFormTitle$Message
 msgid "Shared Scanner Settings"


### PR DESCRIPTION
While I was using an old version, spotted a NASP2 reference - looks like that had been corrected but found a couple more.