### PR TITLE
Add Ctrl+D shortcut to stop multiple scans early

### DIFF
--- a/NAPS2.Lib/Automation/AutomatedScanning.cs
+++ b/NAPS2.Lib/Automation/AutomatedScanning.cs
@@ -735,7 +735,13 @@ internal class AutomatedScanning
                 if (_options.WaitScan)
                 {
                     OutputVerbose(ConsoleResources.PressEnterToScan);
-                    Console.ReadLine();
+                    var input = Console.ReadLine();
+                    if (input == null)
+                    {
+                        // Ctrl+D (EOF) detected - stop scanning and save
+                        OutputVerbose(ConsoleResources.StoppingScan);
+                        break;
+                    }
                 }
                 if (_options.Delay > 0)
                 {

--- a/NAPS2.Lib/Lang/ConsoleResources/ConsoleResources.Designer.cs
+++ b/NAPS2.Lib/Lang/ConsoleResources/ConsoleResources.Designer.cs
@@ -430,7 +430,7 @@ namespace NAPS2.Lang.ConsoleResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Press Enter to scan..
+        ///   Looks up a localized string similar to Press Enter to scan, or Ctrl+D to stop and save..
         /// </summary>
         internal static string PressEnterToScan {
             get {
@@ -481,6 +481,15 @@ namespace NAPS2.Lang.ConsoleResources {
         internal static string StartingScan {
             get {
                 return ResourceManager.GetString("StartingScan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stopping scan and saving....
+        /// </summary>
+        internal static string StoppingScan {
+            get {
+                return ResourceManager.GetString("StoppingScan", resourceCulture);
             }
         }
         

--- a/NAPS2.Lib/Lang/ConsoleResources/ConsoleResources.resx
+++ b/NAPS2.Lib/Lang/ConsoleResources/ConsoleResources.resx
@@ -148,7 +148,7 @@
     <value>Waiting {0}ms...</value>
   </data>
   <data name="PressEnterToScan" xml:space="preserve">
-    <value>Press Enter to scan.</value>
+    <value>Press Enter to scan, or Ctrl+D to stop and save.</value>
   </data>
   <data name="StartingScan" xml:space="preserve">
     <value>Starting scan {0} of {1}...</value>
@@ -268,5 +268,8 @@ Use the "--importpassword" option.</value>
   </data>
   <data name="Cancelling" xml:space="preserve">
     <value>Cancelling... Press Ctrl+C again to terminate.</value>
+  </data>
+  <data name="StoppingScan" xml:space="preserve">
+    <value>Stopping scan and saving...</value>
   </data>
 </root>


### PR DESCRIPTION
Hi, following #743, in order not to change the current behavior, I propose to detect EOF (Ctrl+D, or [Ctrl+Z then Enter](https://stackoverflow.com/a/16136924) on Windows) to interrupt multiple scans started with `--waitscan` by saving the pages scanned up to that point.

I tested the implementation on Windows 10 and it behaves as I expect.
```shell
naps2.console -o "scan.pdf" -n 100 --waitscan --firstnow -v
Beginning scan...
Starting scan 1 of 100...
Scanned page 1.
1 page(s) scanned.
Press Enter to scan, or Ctrl+D to stop and save.

Starting scan 2 of 100...
Scanned page 2.
1 page(s) scanned.
Press Enter to scan, or Ctrl+D to stop and save.
^Z
Stopping scan and saving...
Exporting...
Exporting page 1 of 2.
Exporting page 2 of 2.
Successfully saved PDF file to scan.pdf
```