### PR TITLE
Fix quality drop when image is cropped

### DIFF
--- a/NAPS2.Images/Transforms/AbstractImageTransformer.cs
+++ b/NAPS2.Images/Transforms/AbstractImageTransformer.cs
@@ -173,6 +173,7 @@ internal abstract class AbstractImageTransformer<TImage> where TImage : IMemoryI
 
         var result = ImageContext.Create(width, height, image.PixelFormat);
         result.SetResolution(image.HorizontalResolution, image.VerticalResolution);
+        result.OriginalFileFormat = image.OriginalFileFormat;
         new CopyBitwiseImageOp
         {
             SourceXOffset = x,


### PR DESCRIPTION
If the image is originally scanned with maximum quality, then it would normally save as a png encoded image inside the pdf. However cropping the image would make it save as a jpeg-encoded image. This PR fixes that issue.
