### PR TITLE
Add /config=<name> cmd line argument for using a specified user configuration file

### DIFF
--- a/NAPS2.Lib/Config/Naps2Config.cs
+++ b/NAPS2.Lib/Config/Naps2Config.cs
@@ -25,7 +25,7 @@ public class Naps2Config : ScopedConfig<CommonConfig>
             ConfigScope.Memory<CommonConfig>(),
             ConfigScope.Defaults(InternalDefaults.GetCommonConfig()));
 
-    public Naps2Config(string appConfigPath, string userConfigPath)
+    public Naps2Config(string appConfigPath, string userConfigPath, string? userConfigName = null)
     {
         AppLocked = ConfigScope.File(appConfigPath,
             new ConfigSerializer(ConfigReadMode.LockedOnly, ConfigRootName.AppConfig),
@@ -33,12 +33,14 @@ public class Naps2Config : ScopedConfig<CommonConfig>
         Run = ConfigScope.Memory<CommonConfig>();
         User = ConfigScope.File(userConfigPath, new ConfigSerializer(ConfigReadMode.All, ConfigRootName.UserConfig),
             ConfigScopeMode.ReadWrite);
+        UserConfigName = userConfigName;
         AppDefault = ConfigScope.File(appConfigPath,
             new ConfigSerializer(ConfigReadMode.DefaultOnly, ConfigRootName.AppConfig),
             ConfigScopeMode.ReadOnly);
         InternalDefault = ConfigScope.Defaults(InternalDefaults.GetCommonConfig());
 
         Scopes = new[] { AppLocked, Run, User, AppDefault, InternalDefault };
+        UserConfigName = userConfigName;
     }
 
     public Naps2Config(ConfigScope<CommonConfig> appLocked, ConfigScope<CommonConfig> run,
@@ -87,4 +89,6 @@ public class Naps2Config : ScopedConfig<CommonConfig>
     public ConfigScope<CommonConfig> User { get; }
     public ConfigScope<CommonConfig> AppDefault { get; }
     public ConfigScope<CommonConfig> InternalDefault { get; }
+
+    public string? UserConfigName { get; }
 }

--- a/NAPS2.Lib/EtoForms/Ui/DesktopForm.cs
+++ b/NAPS2.Lib/EtoForms/Ui/DesktopForm.cs
@@ -575,6 +575,8 @@ public abstract class DesktopForm : EtoFormBase
     protected virtual void UpdateTitle(ScanProfile? defaultProfile)
     {
         Title = string.Format(UiStrings.Naps2TitleFormat, defaultProfile?.DisplayName ?? UiStrings.Naps2FullName);
+        if (Config.UserConfigName != null)
+            Title += " (" + Config.UserConfigName + ")";
     }
 
     private void ListViewMouseWheel(object? sender, MouseEventArgs e)

--- a/NAPS2.Lib/Modules/CommonModule.cs
+++ b/NAPS2.Lib/Modules/CommonModule.cs
@@ -49,7 +49,7 @@ public class CommonModule : Module
             configName = configFileOption.Substring("/config=".Length).Trim();
             if (configName != "")
             {
-                if (configName.ContainsAny(Path.GetInvalidFileNameChars()))
+                if (Path.GetInvalidFileNameChars().Any(configName.Contains))
                     configName = null;
                 else
                     configFileName += "_" + configName;

--- a/NAPS2.Lib/Modules/CommonModule.cs
+++ b/NAPS2.Lib/Modules/CommonModule.cs
@@ -46,9 +46,14 @@ public class CommonModule : Module
                                              .FirstOrDefault(s => s.ToLower().StartsWith("/config="));
         if (configFileOption != null)
         {
-            configName = configFileOption.Substring("/config=".Length);
+            configName = configFileOption.Substring("/config=".Length).Trim();
             if (configName != "")
-                configFileName += "_" + configName;
+            {
+                if (configName.ContainsAny(Path.GetInvalidFileNameChars()))
+                    configName = null;
+                else
+                    configFileName += "_" + configName;
+            }
         }
         configFileName += ".xml";
 

--- a/NAPS2.Lib/Modules/CommonModule.cs
+++ b/NAPS2.Lib/Modules/CommonModule.cs
@@ -47,7 +47,9 @@ public class CommonModule : Module
         if (configFileOption != null)
         {
             configName = configFileOption.Substring("/config=".Length).Trim();
-            if (configName != "")
+            if (configName == "")
+                configName = null;
+            else
             {
                 if (Path.GetInvalidFileNameChars().Any(configName.Contains))
                     configName = null;

--- a/NAPS2.Lib/Modules/CommonModule.cs
+++ b/NAPS2.Lib/Modules/CommonModule.cs
@@ -39,9 +39,23 @@ public class CommonModule : Module
         builder.RegisterType<WorkerScanBridge>().AsSelf();
 
         // Config
+        string configFileName = "config";
+        string? configName = null;  // Default: standard config file
+        // Config file suffix specified via command line argument?
+        string? configFileOption = Environment.GetCommandLineArgs()
+                                             .FirstOrDefault(s => s.ToLower().StartsWith("/config="));
+        if (configFileOption != null)
+        {
+            configName = configFileOption.Substring("/config=".Length);
+            if (configName != "")
+                configFileName += "_" + configName;
+        }
+        configFileName += ".xml";
+
         // TODO: Make this a usable path on Mac/Linux
         var config = new Naps2Config(Path.Combine(Paths.Executable, "appsettings.xml"),
-            Path.Combine(Paths.AppData, "config.xml"));
+            Path.Combine(Paths.AppData, configFileName), 
+            configName);   // Remember optional config name
         builder.RegisterInstance(config);
         builder.RegisterBuildCallback(ctx =>
         {


### PR DESCRIPTION
### Background
I'm using my scanner (CanoScan 4400F) to archive documents as PDFs. Business documents need to be stored in a Papra DMS ingestion folder while personal or household documents have to be archived in separate folder structures. I can therefore not currently use a common default file path in the PDF settings but instead have to select the path manually for each document which is tiresome.

### Proposed Solution
The proposed changes attempt to resolve this issue by adding a new command line argument:

    /config=<name>

If such a name is specified it is
  a) used as a suffix for the XML file used to load and store user configuration values, and
  b) displayed in the main window title.

If no such argument is used the behaviour is unchanged. If multiple `/config=...` arguments are used only the first one has an effect.

### Example
For example, specifying `/config=Business` results in the file `config_Business.xml` to be used for the user configuration values.
Additionally the title of the main window will display the configuration name:

<img width="457" height="105" alt="image" src="https://github.com/user-attachments/assets/1cb1e182-dc84-45af-960b-f344441a85e1" />

Any changes to settings values will be saved in `config_Business.xml`. Other user configuration files are not affected.

### Special cases
While best avoided, spaces in configuration names can be used by putting the complete argument in quotes, e. g. `"/config=My Business"`. The configuration name is being checked for invalid file name characters. If any are present, or if its trimmed string is empty, the argument is ignored.

### Usage
This option is mainly intended to be used for AutoPlay event handlers that are applied when buttons on the scanner are pressed. Regular users of the GUI will probably not use it much. Perhaps it can be useful for batch processing as well but I have not yet used that.

On Windows the event handlers for the scanner buttons can now be modified in the registry to use different configurations of with each can define a different default file path. Once the GUI is up and running subsequent invocations (i. e. scanner button clicks) do not change the configuration used at startup even if a command line argument should specify a different one. The window needs to be closed in order to be able to use a different configuration.

Example:
To use the configuration "Business" when clicking the leftmost button (on a CanoScan 4400F) add the argument `/config=Business` to the value of `Cmdline` under the key `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{6bdd1fc6-810f-11d0-bec7-08002be2092f}\0004\Events\PushButtonPushed4\{1C3A7177-F3A7-439E-BE47-E304A185F932}`:

<img width="1617" height="235" alt="image" src="https://github.com/user-attachments/assets/b03b1d22-b05d-4765-a23e-d2c9dd48f372" />

### Platforms
**Windows**: Functional (tested on Windows 10)
**Linux**: Functional (tested on Linux Mint 22)
**Mac OS**: Untested

### Addendum
I have not added or modified tests or documentation. I hope this patch is useful for the project; if there is anything else I can do please let me know.