### PR TITLE
WinForms: Enable maximize/minimize buttons on resizable Eto dialogs

### DIFF
--- a/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsEtoPlatform.cs
+++ b/NAPS2.Lib.WinForms/EtoForms/WinForms/WinFormsEtoPlatform.cs
@@ -268,6 +268,13 @@ public class WinFormsEtoPlatform : EtoPlatform
         form.DpiChanged += (_, _) => (window as IFormBase)?.LayoutController.Invalidate();
     }
 
+    public override void SetFormMaximizable(Window window, bool maximizable)
+    {
+        var form = window.ToNative();
+        form.MaximizeBox = maximizable;
+        form.MinimizeBox = maximizable;
+    }
+
     public override float GetScaleFactor(Window window)
     {
         var form = window.ToNative();

--- a/NAPS2.Lib/EtoForms/EtoPlatform.cs
+++ b/NAPS2.Lib/EtoForms/EtoPlatform.cs
@@ -119,6 +119,10 @@ public abstract class EtoPlatform
     {
     }
 
+    public virtual void SetFormMaximizable(Window window, bool maximizable)
+    {
+    }
+
     public virtual void ConfigureZoomButton(Button button, string icon)
     {
     }

--- a/NAPS2.Lib/EtoForms/FormStateController.cs
+++ b/NAPS2.Lib/EtoForms/FormStateController.cs
@@ -107,6 +107,7 @@ public class FormStateController
             EtoPlatform.Current.SetMinimumClientSize(_window, _minimumClientSize);
         }
         _window.Resizable = Resizable;
+        EtoPlatform.Current.SetFormMaximizable(_window, Resizable);
         Shown = true;
     }
 


### PR DESCRIPTION
## Summary

Fixes #755 — the title-bar maximize button is greyed out on ~30 NAPS2 dialogs on Windows (Preview, Crop, Settings, EditProfile, etc.) even though the windows are user-resizable by drag.

## Root cause

Eto.Forms 2.8.3's `Eto.WinForms.Forms.DialogHandler` constructor hardcodes `MaximizeBox = false` and `MinimizeBox = false` on the underlying `WF.Form`. NAPS2's `EtoDialogBase` sets `Resizable = true`, but Eto's `Resizable` setter only changes `FormBorderStyle` (e.g. to `Sizable`); it does not touch `MaximizeBox`/`MinimizeBox`. Net effect: the form is resizable by drag-handles but the title-bar maximize button stays disabled.

The main window (`DesktopForm` via `EtoFormBase` → Eto `Form`) is unaffected because Eto's `FormHandler` leaves `MaximizeBox = true`.

## Change

Centralized fix in the platform abstraction — no per-dialog edits.

- `EtoPlatform.cs` — new no-op virtual `SetFormMaximizable(Window, bool)`.
- `WinFormsEtoPlatform.cs` — override sets `MaximizeBox` and `MinimizeBox` on `WF.Form`.
- `FormStateController.cs` — call from `OnShownInternal`, immediately after `_window.Resizable = Resizable;`.

`MinimizeBox` is coupled to `MaximizeBox` (both follow the single bool): Eto's `DialogHandler` disabled both, an asymmetric title bar would look odd, and the main `DesktopForm` already shows both.

Mac/GTK keep the no-op base implementation — those platforms already wire `Window.Resizable` to native maximize behavior via Eto's own handlers.

## Affected windows

Now correctly maximizable (~30): Preview, Crop, BlackWhite, BrightCont, HueSat, Sharpen, Rotate, Split, Combine, AdvancedProfile, EditProfile, Settings, Image/Pdf/Email Settings, KeyboardShortcuts, Profiles, Placeholders, ChooseDevice, BatchScan, ScannerSharing, SharedDevice, Resolution, PageSize, AutoSaveSettings, OcrDownload, OcrMultiLang, DownloadProgress, PdfPassword, ManualIp, Error, Progress, EditWith, EmailProvider.

Intentionally unchanged (`FormStateController.Resizable = false`): About, Authorize, BatchPrompt, OcrSetup, Recover. Their `FormBorderStyle = FixedDialog` still hides the maximize button.

DesktopForm: unchanged.

## Bonus

Per-form `Maximized` state is already saved in `FormState` (`FormStateController.cs:166`) and restored on load. With this fix, dialogs can actually become maximized, so that pre-existing facility starts producing user-visible value.