### PR TITLE
Fix SANE custom page size scan failure and improve invalid parameter …

### DIFF
--- a/NAPS2.Sdk/Lang/Resources/SdkResources.Designer.cs
+++ b/NAPS2.Sdk/Lang/Resources/SdkResources.Designer.cs
@@ -103,7 +103,15 @@ namespace NAPS2.Lang.Resources {
                 return ResourceManager.GetString("DeviceOffline", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The scanner rejected the scan settings. Check page size, alignment, and resolution in your profile.
+        /// </summary>
+        internal static string DeviceInvalidParameter {
+            get {
+                return ResourceManager.GetString("DeviceInvalidParameter", resourceCulture);
+            }
+        }        
         /// <summary>
         ///   Looks up a localized string similar to The scanner has a paper jam..
         /// </summary>

--- a/NAPS2.Sdk/Lang/Resources/SdkResources.resx
+++ b/NAPS2.Sdk/Lang/Resources/SdkResources.resx
@@ -123,6 +123,9 @@
   <data name="DeviceOffline" xml:space="preserve">
     <value>The selected scanner is offline.</value>
   </data>
+  <data name="DeviceInvalidParameter" xml:space="preserve">
+    <value>The scanner rejected the scan settings. Check page size, alignment, and resolution in your profile.</value>
+  </data>  
   <data name="DeviceCommunicationFailure" xml:space="preserve">
     <value>Communication with the scanning device was interrupted.</value>
   </data>

--- a/NAPS2.Sdk/Scan/Exceptions/DeviceException.cs
+++ b/NAPS2.Sdk/Scan/Exceptions/DeviceException.cs
@@ -54,3 +54,9 @@ public class DeviceNotFoundException() : DeviceException(SdkResources.DeviceNotF
 /// Indicates the scanning device's automatic document feeder (ADF) has a paper jam that needs to be cleared.
 /// </summary>
 public class DevicePaperJamException() : DeviceException(SdkResources.DevicePaperJam);
+/// <summary>
+/// Indicates the scanner rejected the scan parameters at scan start time.
+/// This typically occurs when page size, geometry, resolution, or other settings
+/// are incompatible with the scanner or backend.
+/// </summary>
+public class DeviceInvalidParameterException() : DeviceException(SdkResources.DeviceInvalidParameter);

--- a/NAPS2.Sdk/Scan/Internal/Sane/SaneScanAreaController.cs
+++ b/NAPS2.Sdk/Scan/Internal/Sane/SaneScanAreaController.cs
@@ -95,7 +95,7 @@ internal class SaneScanAreaController
     public void SetArea(double x1, double y1, double x2, double y2)
     {
         if (!CanSetArea) throw new InvalidOperationException();
-        // Setting just tl/br should be enough, but some backends have an issue where we need to set width/height too
+        // Checking just tl/br should be enough, but some backends have an issue where we need to set width/height too
         // https://gitlab.com/sane-project/backends/-/issues/730
         _optionController.TrySet(SaneOptionNames.PAGE_WIDTH, x2 - x1);
         _optionController.TrySet(SaneOptionNames.PAGE_HEIGHT, y2 - y1);

--- a/NAPS2.Sdk/Scan/Internal/Sane/SaneScanDriver.cs
+++ b/NAPS2.Sdk/Scan/Internal/Sane/SaneScanDriver.cs
@@ -314,8 +314,11 @@ internal class SaneScanDriver : IScanDriver
                     case SaneStatus.DeviceBusy:
                         throw new DeviceBusyException();
                     case SaneStatus.Invalid:
-                        // TODO: Maybe not always correct? e.g. when setting options
-                        throw new DeviceOfflineException();
+                        // SaneStatus.Invalid at this point originates from sane_start (via ScanFrame),
+                        // since SaneOptionController.TrySet handles its own exceptions internally and never
+                        // propagates them. This indicates the scanner rejected the configured scan parameters
+                        // (e.g. page size, geometry, resolution) rather than a connectivity failure.
+                        throw new DeviceInvalidParameterException();
                     case SaneStatus.Jammed:
                         throw new DevicePaperJamException();
                     case SaneStatus.CoverOpen:
@@ -424,8 +427,9 @@ internal class SaneScanDriver : IScanDriver
             var deltaX = maxX - minX - width;
             var offsetX = options.PageAlign switch
             {
-                HorizontalAlign.Left => deltaX,
+                HorizontalAlign.Left => 0,
                 HorizontalAlign.Center => deltaX / 2,
+                HorizontalAlign.Right => deltaX,
                 _ => 0
             };
             scanAreaController.SetArea(minX + offsetX, minY, minX + offsetX + width, minY + height);


### PR DESCRIPTION
…error message

- Fix PageAlign switch in SaneScanDriver.SetOptions where HorizontalAlign.Left and HorizontalAlign.Right cases were swapped, causing non-zero offsetX values for Left-aligned profiles that pushed the scan area to the right edge of the bed. For small custom page sizes (e.g. 3x5 cards) this produced a tl-x value outside the valid range for the configured page-width, causing sane_start to return SaneStatus.Invalid and NAPS2 to report 'scanner is offline'.

- Replace the TODO at SaneScanDriver line 318 with DeviceInvalidParameterException. SaneStatus.Invalid at that point originates from sane_start (SaneOptionController .TrySet handles its own exceptions internally and never propagates them), so it indicates rejected scan parameters rather than a connectivity failure. This also prevents ScanController's device re-query logic from firing unnecessarily on parameter errors.

- Add DeviceInvalidParameterException to DeviceException.cs with a user-facing message directing users to check page size, alignment, and resolution settings.

- Add geometry debug log in SetOptions after SetArea is called, recording tl-x, tl-y, br-x, br-y, width, and height values for diagnostic purposes.

Note: SdkResources.Designer.cs was manually updated as ResGen is not available on Linux. The new DeviceInvalidParameter string should be added to translate.naps2.com for localization.