### PR TITLE
Remove EnablePreviewFeatures from project files

### DIFF
--- a/NAPS2.Setup/targets/CommonTargets.targets
+++ b/NAPS2.Setup/targets/CommonTargets.targets
@@ -2,7 +2,6 @@
     
     <PropertyGroup>
         <LangVersion>14</LangVersion>
-        <EnablePreviewFeatures>true</EnablePreviewFeatures>
         <Copyright>Copyright 2009-2026 NAPS2 Contributors</Copyright>
     </PropertyGroup>
 

--- a/NAPS2.Tools/NAPS2.Tools.csproj
+++ b/NAPS2.Tools/NAPS2.Tools.csproj
@@ -8,7 +8,6 @@
     <AssemblyName>n2</AssemblyName>
     <Configurations>Debug</Configurations>
     <LangVersion>14</LangVersion>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The EnablePreviewFeatures property was removed from CommonTargets.targets and NAPS2.Tools.csproj, disabling preview language features during builds.
#853 