### PR TITLE
Auto-select first added page when no page is selected

### DIFF
--- a/NAPS2.Lib.Tests/Images/DesktopImagesControllerTests.cs
+++ b/NAPS2.Lib.Tests/Images/DesktopImagesControllerTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using NAPS2.EtoForms.Desktop;
+using NAPS2.Sdk.Tests;
+using Xunit;
+
+namespace NAPS2.Lib.Tests.Images;
+
+public class DesktopImagesControllerTests : ContextualTests
+{
+    [Fact]
+    public void ReceiveScannedImage_AutoSelectsNewImage_WhenNothingSelected()
+    {
+        var imageList = new UiImageList();
+        var controller = new DesktopImagesController(imageList);
+        var callback = controller.ReceiveScannedImage();
+
+        callback(CreateScannedImage());
+
+        Assert.Single(imageList.Images);
+        Assert.Single(imageList.Selection);
+        Assert.Equal(imageList.Images[0], imageList.Selection.First());
+    }
+
+    [Fact]
+    public void ReceiveScannedImage_DoesNotChangeSelection_WhenAlreadySelected()
+    {
+        var imageList = new UiImageList();
+        var controller = new DesktopImagesController(imageList);
+        var existingImage = new UiImage(CreateScannedImage());
+        imageList.Mutate(new ListMutation<UiImage>.Append(existingImage));
+        imageList.UpdateSelection(ListSelection.Of(existingImage));
+
+        var callback = controller.ReceiveScannedImage();
+        callback(CreateScannedImage());
+
+        Assert.Equal(2, imageList.Images.Count);
+        Assert.Single(imageList.Selection);
+        Assert.Equal(existingImage, imageList.Selection.First());
+    }
+}

--- a/NAPS2.Lib/EtoForms/Desktop/DesktopImagesController.cs
+++ b/NAPS2.Lib/EtoForms/Desktop/DesktopImagesController.cs
@@ -23,7 +23,12 @@ public class DesktopImagesController
             lock (lockObj)
             {
                 var uiImage = new UiImage(scannedImage);
+                var shouldSelect = !_imageList.Selection.Any();
                 _imageList.Mutate(new ImageListMutation.InsertAfter(uiImage, last), isPassiveInteraction: true);
+                if (shouldSelect)
+                {
+                    _imageList.UpdateSelection(ListSelection.Of(uiImage));
+                }
                 last = uiImage;
             }
         };


### PR DESCRIPTION
## Summary
When a new page is added and there is no current selection, automatically select the newly added page.

## Behavior
- If selection is empty, the newly added page is selected.
- If a page is already selected, selection is unchanged.

## Why
This avoids a confusing first-use flow where image actions remain disabled after scanning because no page is selected.

## Tests
- Added unit tests in NAPS2.Lib.Tests/Images/DesktopImagesControllerTests.cs.
- Verified both: auto-select when empty, and preserve selection when non-empty.

Fixes #855