### PR TITLE
Mac: Route native shortcuts through AppKit

### DIFF
--- a/NAPS2.Lib.Mac/EtoForms/Mac/MacEtoPlatform.cs
+++ b/NAPS2.Lib.Mac/EtoForms/Mac/MacEtoPlatform.cs
@@ -156,12 +156,13 @@ public class MacEtoPlatform : EtoPlatform
         var view = control.ToNative();
         var monitor = NSEvent.AddLocalMonitorForEventsMatchingMask(NSEventMask.KeyDown, evt =>
         {
-            if (ReferenceEquals(evt.Window, view.Window))
-            {
-                var args = evt.ToEtoKeyEventArgs();
-                return handle(args.KeyData) ? null! : evt;
-            }
-            return evt;
+            var args = evt.ToEtoKeyEventArgs();
+            return RouteKeyDown(
+                args.KeyData,
+                () => NSApplication.SharedApplication.MainMenu?.PerformKeyEquivalent(evt) == true,
+                keys => ReferenceEquals(evt.Window, view.Window) && handle(keys))
+                ? null!
+                : evt;
         });
         control.UnLoad += (_, _) => NSEvent.RemoveMonitor(monitor);
     }

--- a/NAPS2.Lib.Tests/EtoForms/EtoPlatformTests.cs
+++ b/NAPS2.Lib.Tests/EtoForms/EtoPlatformTests.cs
@@ -1,0 +1,48 @@
+using Eto.Forms;
+using NAPS2.EtoForms;
+using Xunit;
+
+namespace NAPS2.Lib.Tests.EtoForms;
+
+public class EtoPlatformTests
+{
+    [Fact]
+    public void PlatformShortcutTakesPrecedence()
+    {
+        var appShortcutCalled = false;
+
+        var handled = EtoPlatform.RouteKeyDown(
+            Keys.Application | Keys.Q,
+            () => true,
+            _ =>
+            {
+                appShortcutCalled = true;
+                return true;
+            });
+
+        Assert.True(handled);
+        Assert.False(appShortcutCalled);
+    }
+
+    [Fact]
+    public void AppShortcutHandlesNonPlatformShortcut()
+    {
+        var handled = EtoPlatform.RouteKeyDown(
+            Keys.F2,
+            () => false,
+            keys => keys == Keys.F2);
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public void UnmatchedShortcutRemainsUnhandled()
+    {
+        var handled = EtoPlatform.RouteKeyDown(
+            Keys.F2,
+            () => false,
+            _ => false);
+
+        Assert.False(handled);
+    }
+}

--- a/NAPS2.Lib/EtoForms/EtoPlatform.cs
+++ b/NAPS2.Lib/EtoForms/EtoPlatform.cs
@@ -163,6 +163,12 @@ public abstract class EtoPlatform
         control.KeyDown += (_, args) => args.Handled = handle(args.KeyData);
     }
 
+    internal static bool RouteKeyDown(Keys keyData, Func<bool> handlePlatformShortcut,
+        Func<Keys, bool> handleAppShortcut)
+    {
+        return handlePlatformShortcut() || handleAppShortcut(keyData);
+    }
+
     public virtual void AttachMouseWheelEvent(Control control, EventHandler<MouseEventArgs> eventHandler)
     {
         control.MouseWheel += eventHandler;


### PR DESCRIPTION
## Summary

- make AppKit authoritative for native macOS menu key equivalents before NAPS2 processes application-specific shortcuts
- restore keyboard dispatch for Quit, Minimize, Close, Hide, and standard editing commands without hard-coded command mappings
- add regression coverage for native-first routing, application shortcut handling, and unmatched events

## Validation

- `dotnet run --project NAPS2.Tools -- build debug -v`
- `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 dotnet run --project NAPS2.Tools -- test -v --nogui --nonetwork`
- manually reproduced on NAPS2 8.3.2: the actual AZERTY Command+Q event is ignored while menu-click Quit works
- manually verified the final signed source build: Command+O still opens Import and Command+Q quits the app

Closes #863
Related to #740