### PR TITLE
Fix swapped flatbed/feeder detection in Apple driver GetCaps

### DIFF
--- a/NAPS2.Sdk/Scan/Internal/Apple/DeviceOperator.cs
+++ b/NAPS2.Sdk/Scan/Internal/Apple/DeviceOperator.cs
@@ -301,8 +301,8 @@ internal class DeviceOperator : ICScannerDeviceDelegate
             await _readyTcs.Task;
 
             var unitTypes = _device.AvailableFunctionalUnitTypes;
-            bool supportsFeeder = unitTypes.Contains((NSNumber) (int) ICScannerFunctionalUnitType.Flatbed);
-            bool supportsFlatbed = unitTypes.Contains((NSNumber) (int) ICScannerFunctionalUnitType.DocumentFeeder);
+            bool supportsFlatbed = unitTypes.Contains((NSNumber) (int) ICScannerFunctionalUnitType.Flatbed);
+            bool supportsFeeder = unitTypes.Contains((NSNumber) (int) ICScannerFunctionalUnitType.DocumentFeeder);
             bool supportsDuplex = false;
             PerSourceCaps? flatbedCaps = null;
             PerSourceCaps? feederCaps = null;


### PR DESCRIPTION
In `DeviceOperator.GetCaps()`, the `supportsFeeder` and `supportsFlatbed` variables are assigned from the wrong functional unit types: `supportsFeeder` checks for `ICScannerFunctionalUnitType.Flatbed` and `supportsFlatbed` checks for `ICScannerFunctionalUnitType.DocumentFeeder`.

As a result, `PaperSourceCaps` on macOS is inverted: a flatbed-only scanner reports `SupportsFlatbed = false, SupportsFeeder = true`, and vice versa for feeder-only devices. Nothing downstream compensates for the swap — `FlatbedCaps`/`FeederCaps` are populated independently via actual unit selection, so this is a straightforward variable mix-up.

Verified against an EPSON L3210 (flatbed-only, Apple/ICA driver): `AvailableFunctionalUnitTypes = [Flatbed]`, but before this fix `GetCaps` reported it as feeder-only.

Tested on macOS (Apple Silicon).