### PR TITLE
Advertise real device capabilities in the ESCL server

### DIFF
--- a/NAPS2.Escl.Server/EsclApiController.cs
+++ b/NAPS2.Escl.Server/EsclApiController.cs
@@ -30,7 +30,7 @@ internal class EsclApiController : WebApiController
     [Route(HttpVerbs.Get, "/ScannerCapabilities")]
     public async Task GetScannerCapabilities()
     {
-        var caps = _deviceConfig.Capabilities;
+        var caps = await GetCapabilities();
         var protocol = _securityPolicy.HasFlag(EsclSecurityPolicy.ServerRequireHttps) ? "https" : "http";
         var iconUri = caps.IconPng != null ? $"{protocol}://naps2-{caps.Uuid}.local.:{_deviceConfig.Port}/eSCL/icon.png" : "";
         var doc =
@@ -44,11 +44,7 @@ internal class EsclApiController : WebApiController
                     new XElement(ScanNs + "AdminURI", ""),
                     new XElement(ScanNs + "IconURI", iconUri),
                     new XElement(ScanNs + "Naps2Extensions", "Progress;ErrorDetails;ShortTimeout;AnyDpi"),
-                    new XElement(ScanNs + "Platen",
-                        new XElement(ScanNs + "PlatenInputCaps", GetCommonInputCaps())),
-                    new XElement(ScanNs + "Adf",
-                        new XElement(ScanNs + "AdfSimplexInputCaps", GetCommonInputCaps()),
-                        new XElement(ScanNs + "AdfDuplexInputCaps", GetCommonInputCaps())),
+                    GetInputSourceCaps(caps),
                     new XElement(ScanNs + "CompressionFactorSupport",
                         new XElement(ScanNs + "Min", 0),
                         new XElement(ScanNs + "Max", 100),
@@ -59,22 +55,92 @@ internal class EsclApiController : WebApiController
         await writer.WriteAsync(doc);
     }
 
-    private object[] GetCommonInputCaps()
+    private async Task<EsclCapabilities> GetCapabilities()
     {
-        // TODO: After implementing scanner capabilities this should be scanner-specific
+        if (_deviceConfig.CapabilitiesProvider != null)
+        {
+            try
+            {
+                return await _deviceConfig.CapabilitiesProvider(HttpContext.CancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ESCL server error getting device capabilities; using defaults");
+            }
+        }
+        return _deviceConfig.Capabilities;
+    }
+
+    private object[] GetInputSourceCaps(EsclCapabilities caps)
+    {
+        bool hasKnownSources = caps.PlatenCaps != null || caps.AdfSimplexCaps != null || caps.AdfDuplexCaps != null;
+        if (!hasKnownSources)
+        {
+            // If we don't know the actual device capabilities, advertise all sources with default input caps
+            return
+            [
+                new XElement(ScanNs + "Platen",
+                    new XElement(ScanNs + "PlatenInputCaps", GetInputCaps(null))),
+                new XElement(ScanNs + "Adf",
+                    new XElement(ScanNs + "AdfSimplexInputCaps", GetInputCaps(null)),
+                    new XElement(ScanNs + "AdfDuplexInputCaps", GetInputCaps(null)))
+            ];
+        }
+        var sourceElements = new List<XElement>();
+        if (caps.PlatenCaps != null)
+        {
+            sourceElements.Add(new XElement(ScanNs + "Platen",
+                new XElement(ScanNs + "PlatenInputCaps", GetInputCaps(caps.PlatenCaps))));
+        }
+        if (caps.AdfSimplexCaps != null || caps.AdfDuplexCaps != null)
+        {
+            var adfElement = new XElement(ScanNs + "Adf",
+                new XElement(ScanNs + "AdfSimplexInputCaps", GetInputCaps(caps.AdfSimplexCaps)));
+            if (caps.AdfDuplexCaps != null)
+            {
+                adfElement.Add(new XElement(ScanNs + "AdfDuplexInputCaps", GetInputCaps(caps.AdfDuplexCaps)));
+            }
+            sourceElements.Add(adfElement);
+        }
+        return sourceElements.ToArray<object>();
+    }
+
+    private object[] GetInputCaps(EsclInputCaps? inputCaps)
+    {
+        var profile = inputCaps?.SettingProfiles.FirstOrDefault();
+        object[] colorModes = profile?.ColorModes is { Count: > 0 } modes
+            ? modes.Select(mode => (object) new XElement(ScanNs + "ColorMode", mode.ToString())).ToArray()
+            :
+            [
+                new XElement(ScanNs + "ColorMode", "BlackAndWhite1"),
+                new XElement(ScanNs + "ColorMode", "Grayscale8"),
+                new XElement(ScanNs + "ColorMode", "RGB24")
+            ];
+        object[] resolutions = profile?.DiscreteResolutions is { Count: > 0 } discreteResolutions
+            ? discreteResolutions.Select(res => (object) CreateResolution(res.XResolution, res.YResolution)).ToArray()
+            :
+            [
+                CreateResolution(100),
+                CreateResolution(150),
+                CreateResolution(200),
+                CreateResolution(300),
+                CreateResolution(400),
+                CreateResolution(600),
+                CreateResolution(800),
+                CreateResolution(1200),
+                CreateResolution(2400),
+                CreateResolution(4800)
+            ];
         return
         [
-            new XElement(ScanNs + "MinWidth", "1"),
-            new XElement(ScanNs + "MaxWidth", EsclInputCaps.DEFAULT_MAX_WIDTH),
-            new XElement(ScanNs + "MinHeight", "1"),
-            new XElement(ScanNs + "MaxHeight", EsclInputCaps.DEFAULT_MAX_HEIGHT),
+            new XElement(ScanNs + "MinWidth", inputCaps?.MinWidth ?? 1),
+            new XElement(ScanNs + "MaxWidth", inputCaps?.MaxWidth ?? EsclInputCaps.DEFAULT_MAX_WIDTH),
+            new XElement(ScanNs + "MinHeight", inputCaps?.MinHeight ?? 1),
+            new XElement(ScanNs + "MaxHeight", inputCaps?.MaxHeight ?? EsclInputCaps.DEFAULT_MAX_HEIGHT),
             new XElement(ScanNs + "MaxScanRegions", "1"),
             new XElement(ScanNs + "SettingProfiles",
                 new XElement(ScanNs + "SettingProfile",
-                    new XElement(ScanNs + "ColorModes",
-                        new XElement(ScanNs + "ColorMode", "BlackAndWhite1"),
-                        new XElement(ScanNs + "ColorMode", "Grayscale8"),
-                        new XElement(ScanNs + "ColorMode", "RGB24")),
+                    new XElement(ScanNs + "ColorModes", colorModes),
                     new XElement(ScanNs + "DocumentFormats",
                         new XElement(PwgNs + "DocumentFormat", "application/pdf"),
                         new XElement(PwgNs + "DocumentFormat", "image/jpeg"),
@@ -84,25 +150,16 @@ internal class EsclApiController : WebApiController
                         new XElement(ScanNs + "DocumentFormatExt", "image/png")
                     ),
                     new XElement(ScanNs + "SupportedResolutions",
-                        new XElement(ScanNs + "DiscreteResolutions",
-                            CreateResolution(100),
-                            CreateResolution(150),
-                            CreateResolution(200),
-                            CreateResolution(300),
-                            CreateResolution(400),
-                            CreateResolution(600),
-                            CreateResolution(800),
-                            CreateResolution(1200),
-                            CreateResolution(2400),
-                            CreateResolution(4800)
-                        ))))
+                        new XElement(ScanNs + "DiscreteResolutions", resolutions))))
         ];
     }
 
-    private XElement CreateResolution(int res) =>
+    private XElement CreateResolution(int res) => CreateResolution(res, res);
+
+    private XElement CreateResolution(int xRes, int yRes) =>
         new(ScanNs + "DiscreteResolution",
-            new XElement(ScanNs + "XResolution", res.ToString()),
-            new XElement(ScanNs + "YResolution", res.ToString()));
+            new XElement(ScanNs + "XResolution", xRes.ToString()),
+            new XElement(ScanNs + "YResolution", yRes.ToString()));
 
     [Route(HttpVerbs.Get, "/icon.png")]
     public async Task GetIcon()

--- a/NAPS2.Escl/Server/EsclDeviceConfig.cs
+++ b/NAPS2.Escl/Server/EsclDeviceConfig.cs
@@ -4,6 +4,13 @@ public class EsclDeviceConfig
 {
     public required EsclCapabilities Capabilities { get; init; }
 
+    /// <summary>
+    /// An optional callback that queries the full device capabilities (e.g. paper sources and resolutions from the
+    /// physical device). This may be called for each ScannerCapabilities request, so implementations should cache as
+    /// needed. If this is null or throws an error, Capabilities is used instead.
+    /// </summary>
+    public Func<CancellationToken, Task<EsclCapabilities>>? CapabilitiesProvider { get; init; }
+
     public required Func<EsclScanSettings, IEsclScanJob> CreateJob { get; init; }
 
     public int Port { get; set; }

--- a/NAPS2.Sdk.Tests/Mocks/MockScanBridge.cs
+++ b/NAPS2.Sdk.Tests/Mocks/MockScanBridge.cs
@@ -11,7 +11,9 @@ internal class MockScanBridge : IScanBridge
     public List<ProcessedImage> MockOutput { get; set; } = [];
 
     public List<double> ProgressReports { get; set; } = [];
-        
+
+    public ScanCaps MockCaps { get; set; } = new();
+
     public Exception Error { get; set; }
 
     public ScanOptions LastOptions { get; private set; }
@@ -35,7 +37,12 @@ internal class MockScanBridge : IScanBridge
 
     public Task<ScanCaps> GetCaps(ScanOptions options, CancellationToken cancelToken)
     {
-        return null!;
+        LastOptions = options;
+        if (Error != null)
+        {
+            return Task.FromException<ScanCaps>(Error);
+        }
+        return Task.FromResult(MockCaps);
     }
 
     public Task Scan(ScanOptions options, CancellationToken cancelToken, IScanEvents scanEvents, Action<ProcessedImage, PostProcessingContext> callback)

--- a/NAPS2.Sdk.Tests/Remoting/ScanServerTests.cs
+++ b/NAPS2.Sdk.Tests/Remoting/ScanServerTests.cs
@@ -18,6 +18,69 @@ public class ScanServerTests(ITestOutputHelper testOutputHelper)
     }
 
     [NetworkFact(Timeout = TIMEOUT)]
+    public async Task GetCaps()
+    {
+        _bridge.MockCaps = new ScanCaps
+        {
+            MetadataCaps = new MetadataCaps
+            {
+                Manufacturer = "testManufacturer",
+                SerialNumber = "testSerialNumber"
+            },
+            PaperSourceCaps = new PaperSourceCaps
+            {
+                SupportsFlatbed = true,
+                SupportsFeeder = false,
+                SupportsDuplex = false
+            },
+            FlatbedCaps = new PerSourceCaps
+            {
+                DpiCaps = new DpiCaps { Values = [100, 300, 600] },
+                BitDepthCaps = new BitDepthCaps
+                {
+                    SupportsColor = true,
+                    SupportsGrayscale = true,
+                    SupportsBlackAndWhite = false
+                },
+                PageSizeCaps = new PageSizeCaps { ScanArea = PageSize.Letter }
+            }
+        };
+        var caps = await _client.GetCaps(_clientDevice);
+        Assert.Equal("testManufacturer", caps.MetadataCaps?.Manufacturer);
+        Assert.Equal("testSerialNumber", caps.MetadataCaps?.SerialNumber);
+        Assert.NotNull(caps.PaperSourceCaps);
+        Assert.True(caps.PaperSourceCaps.SupportsFlatbed);
+        Assert.False(caps.PaperSourceCaps.SupportsFeeder);
+        Assert.False(caps.PaperSourceCaps.SupportsDuplex);
+        Assert.Null(caps.FeederCaps);
+        Assert.Null(caps.DuplexCaps);
+        Assert.NotNull(caps.FlatbedCaps);
+        Assert.Equal(new[] { 100, 300, 600 }, caps.FlatbedCaps.DpiCaps?.Values);
+        Assert.NotNull(caps.FlatbedCaps.BitDepthCaps);
+        Assert.True(caps.FlatbedCaps.BitDepthCaps.SupportsColor);
+        Assert.True(caps.FlatbedCaps.BitDepthCaps.SupportsGrayscale);
+        Assert.False(caps.FlatbedCaps.BitDepthCaps.SupportsBlackAndWhite);
+        Assert.Equal(8.5m, caps.FlatbedCaps.PageSizeCaps?.ScanArea?.WidthInInches);
+        Assert.Equal(11m, caps.FlatbedCaps.PageSizeCaps?.ScanArea?.HeightInInches);
+    }
+
+    [NetworkFact(Timeout = TIMEOUT)]
+    public async Task GetCapsWhenUnavailable()
+    {
+        // If the backend can't provide caps (e.g. the physical device is offline), we should fall back to a default
+        // set of capabilities.
+        _bridge.Error = new DeviceException(SdkResources.DeviceOffline);
+        var caps = await _client.GetCaps(_clientDevice);
+        Assert.NotNull(caps.PaperSourceCaps);
+        Assert.True(caps.PaperSourceCaps.SupportsFlatbed);
+        Assert.True(caps.PaperSourceCaps.SupportsFeeder);
+        Assert.True(caps.PaperSourceCaps.SupportsDuplex);
+        Assert.NotNull(caps.FlatbedCaps);
+        Assert.NotNull(caps.FeederCaps);
+        Assert.NotNull(caps.DuplexCaps);
+    }
+
+    [NetworkFact(Timeout = TIMEOUT)]
     public async Task Scan()
     {
         _bridge.MockOutput = CreateScannedImages(ImageResources.dog);

--- a/NAPS2.Sdk/Remoting/Server/ScanServer.cs
+++ b/NAPS2.Sdk/Remoting/Server/ScanServer.cs
@@ -1,4 +1,6 @@
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Microsoft.Extensions.Logging;
 using NAPS2.Escl;
 using NAPS2.Escl.Server;
 using NAPS2.Scan;
@@ -87,19 +89,109 @@ public class ScanServer : IDisposable
 
     private EsclDeviceConfig MakeEsclDeviceConfig(ScanServerDevice device)
     {
+        var baseCapabilities = new EsclCapabilities
+        {
+            MakeAndModel = device.Name,
+            Uuid = device.GetUuid(InstanceId),
+            IconPng = _defaultIconPng
+        };
         return new EsclDeviceConfig
         {
             Port = device.Port,
             TlsPort = device.TlsPort,
-            Capabilities = new EsclCapabilities
-            {
-                MakeAndModel = device.Name,
-                Uuid = device.GetUuid(InstanceId),
-                IconPng = _defaultIconPng,
-                // TODO: Ideally we want to get the actual device capabilities (flatbed/feeder, resolution etc.)
-            },
+            Capabilities = baseCapabilities,
+            CapabilitiesProvider = MakeCapabilitiesProvider(device, baseCapabilities),
             CreateJob = settings => new ScanJob(_scanningContext, ScanControllerFactory(), device.Device, settings)
         };
+    }
+
+    /// <summary>
+    /// Creates a callback that queries the shared device for its actual capabilities (paper sources, resolutions etc.)
+    /// so they can be advertised to ESCL clients. The result is queried lazily on the first request and then cached.
+    /// If the query fails (e.g. the device is offline or the driver doesn't support querying capabilities), the
+    /// default capabilities are used and the query is retried on the next request.
+    /// </summary>
+    private Func<CancellationToken, Task<EsclCapabilities>> MakeCapabilitiesProvider(
+        ScanServerDevice device, EsclCapabilities baseCapabilities)
+    {
+        EsclCapabilities? cached = null;
+        var mutex = new SemaphoreSlim(1, 1);
+        return async cancelToken =>
+        {
+            await mutex.WaitAsync(cancelToken);
+            try
+            {
+                if (cached != null) return cached;
+                try
+                {
+                    var scanCaps = await ScanControllerFactory().GetCaps(device.Device, cancelToken);
+                    cached = MergeCaps(baseCapabilities, scanCaps);
+                    return cached;
+                }
+                catch (Exception ex)
+                {
+                    _scanningContext.Logger.LogError(ex, "Error getting capabilities for shared device");
+                    return baseCapabilities;
+                }
+            }
+            finally
+            {
+                mutex.Release();
+            }
+        };
+    }
+
+    private static EsclCapabilities MergeCaps(EsclCapabilities baseCapabilities, ScanCaps scanCaps)
+    {
+        var paperSourceCaps = scanCaps.PaperSourceCaps;
+        return new EsclCapabilities
+        {
+            MakeAndModel = baseCapabilities.MakeAndModel,
+            Uuid = baseCapabilities.Uuid,
+            IconPng = baseCapabilities.IconPng,
+            SerialNumber = scanCaps.MetadataCaps?.SerialNumber,
+            Manufacturer = scanCaps.MetadataCaps?.Manufacturer,
+            PlatenCaps = paperSourceCaps is { SupportsFlatbed: true }
+                ? MapInputCaps(scanCaps.FlatbedCaps)
+                : null,
+            AdfSimplexCaps = paperSourceCaps is { SupportsFeeder: true }
+                ? MapInputCaps(scanCaps.FeederCaps)
+                : null,
+            AdfDuplexCaps = paperSourceCaps is { SupportsDuplex: true }
+                ? MapInputCaps(scanCaps.DuplexCaps)
+                : null
+        };
+    }
+
+    private static EsclInputCaps MapInputCaps(PerSourceCaps? caps)
+    {
+        var inputCaps = new EsclInputCaps();
+        if (caps?.PageSizeCaps?.ScanArea is { } scanArea)
+        {
+            // ESCL width/height values are in 1/300ths of an inch
+            inputCaps.MaxWidth = (int) (scanArea.WidthInInches * 300);
+            inputCaps.MaxHeight = (int) (scanArea.HeightInInches * 300);
+        }
+        var colorModes = new List<EsclColorMode>();
+        if (caps?.BitDepthCaps is { } bitDepthCaps)
+        {
+            if (bitDepthCaps.SupportsBlackAndWhite) colorModes.Add(EsclColorMode.BlackAndWhite1);
+            if (bitDepthCaps.SupportsGrayscale) colorModes.Add(EsclColorMode.Grayscale8);
+            if (bitDepthCaps.SupportsColor) colorModes.Add(EsclColorMode.RGB24);
+        }
+        // We use CommonValues rather than Values as some drivers report a large or continuous range of resolutions
+        // that would be unreasonable to fully enumerate in the capabilities XML.
+        var resolutions = caps?.DpiCaps?.CommonValues?.Where(dpi => dpi > 0).ToList();
+        if (colorModes.Count > 0 || resolutions is { Count: > 0 })
+        {
+            inputCaps.SettingProfiles.Add(new EsclSettingProfile
+            {
+                ColorModes = colorModes,
+                DiscreteResolutions =
+                    resolutions?.Select(dpi => new DiscreteResolution(dpi, dpi)).ToList() ?? []
+            });
+        }
+        return inputCaps;
     }
 
     public Task Start() => _esclServer.Start();


### PR DESCRIPTION
This closes the TODO in `ScanServer.MakeEsclDeviceConfig` ("Ideally we want to get the actual device capabilities (flatbed/feeder, resolution etc.)").

## What changes

- `EsclDeviceConfig` gets an optional `CapabilitiesProvider` callback that can asynchronously supply full `EsclCapabilities`.
- `ScanServer` implements the provider by calling `ScanController.GetCaps()` (the same API the profile dialog uses via `DeviceCapsCache`) and mapping `ScanCaps`/`PerSourceCaps` to the existing `EsclCapabilities.PlatenCaps`/`AdfSimplexCaps`/`AdfDuplexCaps` fields, which so far were only used by the ESCL client.
- `EsclApiController.GetScannerCapabilities` generates the Platen/Adf sections from those fields when they are populated, advertising **only the paper sources the device actually has**, with its real resolutions, color modes and max scan area.

## Design notes

- **Lazy + cached:** capabilities are queried on the first `ScannerCapabilities` request rather than at registration, so sharing devices doesn't open device sessions at startup and server startup is never blocked. A successful query is cached for the lifetime of the registration; a failed query falls back to the defaults and is retried on the next request (same policy as `DeviceCapsCache`).
- **Unchanged fallback:** if the driver doesn't provide capabilities (e.g. the current WIA/TWAIN paths), the device is offline, or the query fails, the generated XML is exactly the same as before (Platen + AdfSimplex + AdfDuplex with the default 100-4800 resolution list and A3 max size). No behavior change for setups without caps.
- Resolutions are taken from `DpiCaps.CommonValues` rather than `Values`, since some drivers (e.g. Apple/ICA) report a continuous range with thousands of values that would be unreasonable to enumerate in the XML.
- The ESCL client is untouched; standard clients (AirScan/iOS, sane-airscan) that respect the advertised capabilities are the main beneficiaries, since they will no longer offer a non-existent ADF or out-of-range resolutions/page sizes.

## Testing

- New `ScanServerTests.GetCaps` round-trip test (server announces caps from a mock backend, ESCL client parses them back) and `ScanServerTests.GetCapsWhenUnavailable` fallback test; ran the `Remoting` test suite plus `NAPS2.Escl.Tests` on macOS (arm64). One pre-existing failure (`ScanWithCorrectOptions`, `DeviceBusyException` when running the whole suite in parallel) reproduces identically on clean master on this machine and is unrelated.
- Tested against real hardware: an EPSON L3210 (flatbed-only) shared through the Apple/ICA driver on macOS. The server now advertises Platen only (no phantom ADF), the real 8.5x11.7" scan area (2550x3509 in 1/300"), the device serial number, and the driver's preferred resolutions (75-9600), and falls back to the previous XML while the device query hasn't succeeded yet. Verified the cached path returns the same document.

Note: for correct results with the Apple driver this depends on #887 (flatbed/feeder swap in `DeviceOperator.GetCaps`); without it a flatbed-only Mac device is reported as feeder-only. The two PRs are independent code-wise.
