### PR TITLE
Fix misspelled ESCL AdfState value ScannedAdfLoaded -> ScannerAdfLoaded

### DIFF
--- a/NAPS2.Escl.Server/EsclApiController.cs
+++ b/NAPS2.Escl.Server/EsclApiController.cs
@@ -138,7 +138,7 @@ internal class EsclApiController : WebApiController
                         jobInfo.State == EsclJobState.Processing ? "JobScanning" : "JobCompletedSuccessfully"))));
         }
         var scannerState = _serverState.IsProcessing ? EsclScannerState.Processing : EsclScannerState.Idle;
-        var adfState = _serverState.IsProcessing ? EsclAdfState.ScannerAdfProcessing : EsclAdfState.ScannedAdfLoaded;
+        var adfState = _serverState.IsProcessing ? EsclAdfState.ScannerAdfProcessing : EsclAdfState.ScannerAdfLoaded;
         var doc =
             EsclXmlHelper.CreateDocAsString(
                 new XElement(ScanNs + "ScannerStatus",

--- a/NAPS2.Escl/Client/EsclClient.cs
+++ b/NAPS2.Escl/Client/EsclClient.cs
@@ -118,10 +118,16 @@ public class EsclClient
         return new EsclScannerStatus
         {
             State = ParseHelper.MaybeParseEnum(root.Element(PwgNs + "State"), EsclScannerState.Unknown),
-            AdfState = ParseHelper.MaybeParseEnum(root.Element(ScanNs + "AdfState"), EsclAdfState.Unknown),
+            AdfState = ParseAdfState(root.Element(ScanNs + "AdfState")),
             JobStates = jobStates
         };
     }
+
+    private static EsclAdfState ParseAdfState(XElement? element) =>
+        // NAPS2 servers before this fix misspelled ScannerAdfLoaded as "ScannedAdfLoaded"
+        element?.Value == "ScannedAdfLoaded"
+            ? EsclAdfState.ScannerAdfLoaded
+            : ParseHelper.MaybeParseEnum(element, EsclAdfState.Unknown);
 
     public async Task<EsclJob> CreateScanJob(EsclScanSettings settings)
     {

--- a/NAPS2.Escl/EsclAdfState.cs
+++ b/NAPS2.Escl/EsclAdfState.cs
@@ -6,7 +6,7 @@ public enum EsclAdfState
     ScannerAdfProcessing,
     ScannerAdfEmpty,
     ScannerAdfJam,
-    ScannedAdfLoaded,
+    ScannerAdfLoaded,
     ScannerAdfMispick,
     ScannerAdfHatchOpen,
     ScannerAdfDuplexPageTooShort,

--- a/NAPS2.Sdk/Scan/Internal/Escl/EsclScanDriver.cs
+++ b/NAPS2.Sdk/Scan/Internal/Escl/EsclScanDriver.cs
@@ -398,7 +398,7 @@ internal class EsclScanDriver : IScanDriver
                 throw new DevicePaperJamException();
             }
             if (status.AdfState is not (EsclAdfState.Unknown or EsclAdfState.ScannerAdfProcessing
-                or EsclAdfState.ScannedAdfLoaded))
+                or EsclAdfState.ScannerAdfLoaded))
             {
                 throw new DeviceException(status.AdfState.ToString());
             }


### PR DESCRIPTION
`EsclAdfState.ScannedAdfLoaded` is a misspelling of the standard eSCL `AdfState` value `ScannerAdfLoaded`. All values of this enum come from the `Scanner*` family, and the rest of the ecosystem consistently uses the `ScannerAdfLoaded` spelling; a few references:

- sane-airscan: [`airscan-escl.c`](https://github.com/alexpevzner/sane-airscan/blob/master/airscan-escl.c) parses `ScannerAdfLoaded`
- AirSane: [`server/scanner.cpp`](https://github.com/SimulPiscator/AirSane/blob/master/server/scanner.cpp) emits `ScannerAdfLoaded`
- HP's published eSCL protocol documentation also uses `ScannerAdfLoaded`

Searching GitHub for `ScannedAdfLoaded` only turns up NAPS2 itself.

## What changes

- The enum value is renamed to `ScannerAdfLoaded`, so the ESCL server now reports the standard spelling in `ScannerStatus`, which third-party clients that inspect `AdfState` can actually recognize.
- The client's status parsing explicitly maps the legacy `"ScannedAdfLoaded"` string to `ScannerAdfLoaded`, so a new NAPS2 client talking to an older NAPS2 server still parses the status correctly.

## Compatibility

- New client -> old NAPS2 server: handled by the legacy mapping above.
- Old client -> new server: the old client fails to parse `"ScannerAdfLoaded"` and falls back to `EsclAdfState.Unknown`, which `EsclScanDriver.VerifyStatus` already treats as non-error, so scanning is unaffected.
- This renames a public enum member in the NAPS2.Escl package, so it's technically a source-breaking change for package consumers referencing the misspelled name.

Built `NAPS2.Sdk`/`NAPS2.Escl.Server` and ran `NAPS2.Escl.Tests` plus the `Remoting.ScanServerTests` client/server round-trip suite (which exercises `ScannerStatus` parsing) on macOS.
